### PR TITLE
docs(readme): add missing target

### DIFF
--- a/packages/nx-spring-boot/README.md
+++ b/packages/nx-spring-boot/README.md
@@ -96,7 +96,7 @@ Here the list of available builders:
 ### Running the application - ('run' Builder)
 
 ```
-nx run your-boot-app
+nx run your-boot-app:run
 ```
 
 You can pass in additional arguments by editing the related section in the `workspace.json` file, as such:


### PR DESCRIPTION
Using only `nx run your-boot-app` Nx will ask to `Specify the project name and the target (e.g., nx run proj:build)`