### PR TITLE
fix(nx-spring-boot): set correct path for executors

### DIFF
--- a/packages/nx-spring-boot/executors.json
+++ b/packages/nx-spring-boot/executors.json
@@ -1,33 +1,33 @@
 {
   "executors": {
     "run": {
-      "implementation": "./src/builders/run/executor",
-      "schema": "./src/builders/run/schema.json",
+      "implementation": "./src/executors/run/executor",
+      "schema": "./src/executors/run/schema.json",
       "description": "Executor to run the application"
     },
     "serve": {
-      "implementation": "./src/builders/run/executor",
-      "schema": "./src/builders/serve/schema.json",
+      "implementation": "./src/executors/run/executor",
+      "schema": "./src/executors/serve/schema.json",
       "description": "Executor to serve the application (alias to 'run' executor)"
     },
     "test": {
-      "implementation": "./src/builders/test/executor",
-      "schema": "./src/builders/test/schema.json",
+      "implementation": "./src/executors/test/executor",
+      "schema": "./src/executors/test/schema.json",
       "description": "Executor to test the application"
     },
     "clean": {
-      "implementation": "./src/builders/clean/executor",
-      "schema": "./src/builders/clean/schema.json",
+      "implementation": "./src/executors/clean/executor",
+      "schema": "./src/executors/clean/schema.json",
       "description": "Executor to clean the application"
     },
     "buildJar": {
-      "implementation": "./src/builders/build-jar/executor",
-      "schema": "./src/builders/build-jar/schema.json",
+      "implementation": "./src/executors/build-jar/executor",
+      "schema": "./src/executors/build-jar/schema.json",
       "description": "Executor to build the application's executable Jar"
     },
     "buildWar": {
-      "implementation": "./src/builders/build-war/executor",
-      "schema": "./src/builders/build-war/schema.json",
+      "implementation": "./src/executors/build-war/executor",
+      "schema": "./src/executors/build-war/schema.json",
       "description": "Executor to build the application's executable War"
     },
     "buildImage": {
@@ -38,7 +38,7 @@
     "buildInfo": {
       "implementation": "./src/executors/build-info/executor",
       "schema": "./src/executors/build-info/schema.json",
-      "description": "Executor to build the applications's build information"
+      "description": "Executor to build the application's build information"
     }
   }
 }

--- a/packages/nx-spring-boot/src/executors/test/schema.json
+++ b/packages/nx-spring-boot/src/executors/test/schema.json
@@ -10,7 +10,7 @@
       "type": "string"
     },
     "ignoreWrapper": {
-      "description": "Whether or not to use the embedded wrapper (`mvnw`or `gradlew`) to perfom build operations",
+      "description": "Whether or not to use the embedded wrapper (`mvnw`or `gradlew`) to perform build operations",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
Hi there

In 47231fd9 you refactored the executors from `src/builders/x` to `src/executors/x` without adjusting the `executors.json` to the new paths. This PR fixes this (and also two minor typos I found on the way).