### PR TITLE
fix: plugins include spec files in distributed pkg

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -36,7 +36,12 @@
               "packages/nx-spring-boot/*.md",
               {
                 "input": "./packages/nx-spring-boot/src",
-                "glob": "**/*.!(ts)",
+                "glob": "**/!(*.ts)",
+                "output": "./src"
+              },
+              {
+                "input": "./packages/nx-spring-boot/src",
+                "glob": "**/*.d.ts",
                 "output": "./src"
               },
               {
@@ -115,7 +120,12 @@
               "packages/nx-flutter/*.md",
               {
                 "input": "./packages/nx-flutter/src",
-                "glob": "**/*.!(ts)",
+                "glob": "**/!(*.ts)",
+                "output": "./src"
+              },
+              {
+                "input": "./packages/nx-flutter/src",
+                "glob": "**/*.d.ts",
                 "output": "./src"
               },
               {


### PR DESCRIPTION
Both plugins include spec files in their distributed package. 

For more context see: https://github.com/nrwl/nx/issues/5563