### PR TITLE
feat(nx-spring-boot): make jar of `library` projects not executable

### DIFF
--- a/packages/nx-spring-boot/src/generators/project/generator.ts
+++ b/packages/nx-spring-boot/src/generators/project/generator.ts
@@ -1,13 +1,19 @@
 import { Tree, addProjectConfiguration, } from '@nrwl/devkit';
 import { ProjectGeneratorOptions } from './schema';
-import { normalizeOptions, generateBootProject, addBuilInfoTask, addPluginToNxJson } from './lib';
+import { normalizeOptions, generateBootProject, addBuilInfoTask, addPluginToNxJson, disableBootJarTask, removeBootMavenPlugin } from './lib';
 
 
 export async function projectGenerator(tree: Tree, options: ProjectGeneratorOptions) {
-  const normalizedOptions = normalizeOptions(tree,options);
+  const normalizedOptions = normalizeOptions(tree, options);
 
   const targets = {};
-  const commands = ['run', 'serve', 'test', 'clean', 'buildJar', 'buildWar', 'buildImage', 'buildInfo'];
+  const commands = ['run', 'serve', 'test', 'clean'];
+  const bootOnlyCommands = ['buildJar', 'buildWar', 'buildImage', 'buildInfo'];
+
+  if (options.projectType === 'application') { //only 'application' projects should have 'boot' related commands
+    commands.push(...bootOnlyCommands);
+  }
+
   for (const command of commands) {
     targets[command] = {
       executor: `@nxrocks/nx-spring-boot:${command}`,
@@ -26,6 +32,10 @@ export async function projectGenerator(tree: Tree, options: ProjectGeneratorOpti
 
   await generateBootProject(tree, normalizedOptions);
   addBuilInfoTask(tree, normalizedOptions);
+
+  disableBootJarTask(tree, normalizedOptions);
+  removeBootMavenPlugin(tree, normalizedOptions);
+
   addPluginToNxJson(tree);
 }
 

--- a/packages/nx-spring-boot/src/generators/project/lib/add-build-info-task.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/add-build-info-task.ts
@@ -5,7 +5,7 @@ import {
 import { NormalizedSchema } from '../schema';
 
 export function addBuilInfoTask(tree: Tree, options: NormalizedSchema) {
-    if (options.buildSystem === 'gradle-project') {
+    if (options.projectType === 'application' && options.buildSystem === 'gradle-project') {
         logger.debug(`Adding 'buildInfo' task to the build.gradle file...`);
 
         const buildInfoTask = `

--- a/packages/nx-spring-boot/src/generators/project/lib/disable-boot-jar-task.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/disable-boot-jar-task.ts
@@ -1,0 +1,29 @@
+import {
+    logger,
+    Tree
+} from '@nrwl/devkit';
+import { NormalizedSchema } from '../schema';
+
+export function disableBootJarTask(tree: Tree, options: NormalizedSchema) {
+    if (options.projectType === 'library' && options.buildSystem === 'gradle-project') {
+        logger.debug(`Disabling 'bootJar' task on a library project...`);
+
+        const bootJarDisabledTask = `
+// spring boot library projects don't need an executable jar, so we disable it
+bootJar {
+    enabled = false
+}
+`;
+        const jarEnabledTask = `
+jar {
+    enabled = true
+}
+`;
+        const ext = options.language === 'kotlin' ? '.kts' : ''
+        const buildGradlePath = `${options.projectRoot}/build.gradle${ext}`;
+        let content = tree.read(buildGradlePath).toString();
+
+        content += bootJarDisabledTask + '\n' + jarEnabledTask;
+        tree.write(buildGradlePath, content);
+    }
+}

--- a/packages/nx-spring-boot/src/generators/project/lib/index.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/index.ts
@@ -1,4 +1,6 @@
  export { generateBootProject } from './generate-boot-project';
  export { addPluginToNxJson } from './add-plugin-to-nx-json'
  export { addBuilInfoTask } from './add-build-info-task';
+ export { disableBootJarTask } from './disable-boot-jar-task';
+ export { removeBootMavenPlugin } from './remove-spring-boot-plugin';
  export { normalizeOptions } from './normalize-options';

--- a/packages/nx-spring-boot/src/generators/project/lib/remove-spring-boot-plugin.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/remove-spring-boot-plugin.ts
@@ -1,0 +1,27 @@
+import {
+    logger,
+    Tree
+} from '@nrwl/devkit';
+import { NormalizedSchema } from '../schema';
+
+export function removeBootMavenPlugin(tree: Tree, options: NormalizedSchema) {
+    if (options.projectType === 'library' && options.buildSystem === 'maven-project') {
+        logger.debug(`Removing 'spring-boot' maven plugin on a library project...`);
+
+        const mvnPlugin = `
+<build>
+    <plugins>
+        <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+    </plugins>
+</build>
+`;
+        const pomXmlPath = `${options.projectRoot}/pom.xml`;
+        let content = tree.read(pomXmlPath).toString();
+
+        content = content.replace(mvnPlugin, '');
+        tree.write(pomXmlPath, content);
+    }
+}


### PR DESCRIPTION
Moreover, only add 'boot' related executors  to `workspace.json`  for `application` projects

Closes #67