### PR TITLE
test(common): add `ensureNxProjectWithDeps` to ease e2e testing setup

### DIFF
--- a/.github/workflows/run-e2e-tests-nx-flutter.yml
+++ b/.github/workflows/run-e2e-tests-nx-flutter.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Run e2e tests
         env:
-          npm_config_registry: http://localhost:4873
-          YARN_REGISTRY: http://localhost:4873
           NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node-version }}
           NX_VERBOSE_LOGGING: ${{ 'true' }}
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}

--- a/.github/workflows/run-e2e-tests-nx-quarkus.yml
+++ b/.github/workflows/run-e2e-tests-nx-quarkus.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Run e2e tests
         env:
-          npm_config_registry: http://localhost:4872
-          YARN_REGISTRY: http://localhost:4872
           NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node-version }}
           NX_VERBOSE_LOGGING: ${{ 'true' }}
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}

--- a/.github/workflows/run-e2e-tests-nx-spring-boot.yml
+++ b/.github/workflows/run-e2e-tests-nx-spring-boot.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Run e2e tests
         env:
-          npm_config_registry: http://localhost:4871
-          YARN_REGISTRY: http://localhost:4871
           NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node-version }}
           NX_VERBOSE_LOGGING: ${{ 'true' }}
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}

--- a/e2e/nx-flutter-e2e/tests/nx-flutter.test.ts
+++ b/e2e/nx-flutter-e2e/tests/nx-flutter.test.ts
@@ -1,36 +1,21 @@
 import {
   checkFilesExist,
-  ensureNxProject,
   readJson,
   runNxCommandAsync,
   uniq,
 } from '@nrwl/nx-plugin/testing';
-import { buildAndPublishPackages, disableVerdaccioRegistry, enableVerdaccioRegistry, spawnVerdaccioRegistry } from '@nxrocks/common/testing';
+import { ensureNxProjectWithDeps } from '@nxrocks/common/testing';
 
 jest.mock('inquirer'); // we mock 'inquirer' to bypass the interactive prompt
 import * as inquirer from 'inquirer';
 
 xdescribe('nx-flutter e2e', () => {
-  const verdaccioPort = 4873;
-  let verdaccioRegistry;
 
   beforeAll(async () => {
-    verdaccioRegistry = await spawnVerdaccioRegistry(verdaccioPort);
-    enableVerdaccioRegistry(verdaccioPort);
 
-    process.env.NX_E2E_SKIP_BUILD_CLEANUP = 'true';
-    await buildAndPublishPackages(verdaccioPort);
-    
-    ensureNxProject('@nxrocks/nx-flutter', 'dist/packages/nx-flutter');
+    ensureNxProjectWithDeps('@nxrocks/nx-flutter', 'dist/packages/nx-flutter',
+      [{ depPkgName: '@nxrocks/common', depDistPath: 'dist/packages/common' }]);
   }, 600000);
-
-  afterAll(() => {
-    disableVerdaccioRegistry();
-
-    if (verdaccioRegistry) {
-      verdaccioRegistry.kill();
-    }
-  });
   
   beforeEach(() => {
     jest.spyOn(inquirer, 'prompt').mockResolvedValue({

--- a/e2e/nx-quarkus-e2e/tests/nx-quarkus.test.ts
+++ b/e2e/nx-quarkus-e2e/tests/nx-quarkus.test.ts
@@ -1,37 +1,23 @@
 import {
   checkFilesExist,
-  ensureNxProject,
   readFile,
   readJson,
   runNxCommandAsync,
   uniq,
   tmpProjPath
 } from '@nrwl/nx-plugin/testing';
-import { spawnVerdaccioRegistry, enableVerdaccioRegistry, buildAndPublishPackages, disableVerdaccioRegistry } from '@nxrocks/common/testing';
+import { ensureNxProjectWithDeps } from '@nxrocks/common/testing';
 
 import { lstatSync } from 'fs';
 
 describe('nx-quarkus e2e', () => {
   const isWin = process.platform === "win32";
-  const verdaccioPort = 4872;
-  let verdaccioRegistry;
 
   beforeAll(async () => {
-    verdaccioRegistry = await spawnVerdaccioRegistry(verdaccioPort);
-    enableVerdaccioRegistry(verdaccioPort);
 
-    await buildAndPublishPackages(verdaccioPort);
-    
-    ensureNxProject('@nxrocks/nx-quarkus', 'dist/packages/nx-quarkus');
+    ensureNxProjectWithDeps('@nxrocks/nx-quarkus', 'dist/packages/nx-quarkus',
+      [{ depPkgName: '@nxrocks/common', depDistPath: 'dist/packages/common' }]);
   }, 600000);
-
-  afterAll(() => {
-    disableVerdaccioRegistry();
-
-    if (verdaccioRegistry) {
-      verdaccioRegistry.kill();
-    }
-  });
   
   it('should create nx-quarkus with default options', async() => {
     const prjName = uniq('nx-quarkus');

--- a/e2e/nx-spring-boot-e2e/tests/nx-spring-boot.test.ts
+++ b/e2e/nx-spring-boot-e2e/tests/nx-spring-boot.test.ts
@@ -1,6 +1,5 @@
 import {
   checkFilesExist,
-  ensureNxProject,
   readFile,
   readJson,
   runNxCommandAsync,
@@ -8,31 +7,18 @@ import {
   tmpProjPath
 } from '@nrwl/nx-plugin/testing';
 import { names } from '@nrwl/devkit';
-import {buildAndPublishPackages, disableVerdaccioRegistry, enableVerdaccioRegistry, spawnVerdaccioRegistry } from '@nxrocks/common/testing';
+import {ensureNxProjectWithDeps} from '@nxrocks/common/testing';
 
 import { lstatSync } from 'fs';
 
 describe('nx-spring-boot e2e', () => {
   const isWin = process.platform === "win32";
-  const verdaccioPort = 4871;
-  let verdaccioRegistry;
 
   beforeAll(async () => {
-    verdaccioRegistry = await spawnVerdaccioRegistry(verdaccioPort);
-    enableVerdaccioRegistry(verdaccioPort);
 
-    await buildAndPublishPackages(verdaccioPort);
-    
-    ensureNxProject('@nxrocks/nx-spring-boot', 'dist/packages/nx-spring-boot');
+    ensureNxProjectWithDeps('@nxrocks/nx-spring-boot', 'dist/packages/nx-spring-boot',
+      [{ depPkgName: '@nxrocks/common', depDistPath: 'dist/packages/common' }]);
   }, 600000);
-
-  afterAll(() => {
-    disableVerdaccioRegistry();
-
-    if (verdaccioRegistry) {
-      verdaccioRegistry.kill();
-    }
-  });
 
   it('should create nx-spring-boot with default options', async() => {
     const prjName = uniq('nx-spring-boot');

--- a/packages/common/src/lib/testing/e2e/ensure-nx-project.ts
+++ b/packages/common/src/lib/testing/e2e/ensure-nx-project.ts
@@ -1,0 +1,63 @@
+
+import { ensureDirSync } from "fs-extra";
+import { execSync } from 'child_process';
+import { dirname, join } from 'path';
+import {
+  cleanup,
+  patchPackageJsonForPlugin,
+  runPackageManagerInstall,
+  tmpProjPath
+} from '@nrwl/nx-plugin/testing';
+import { readJsonFile, writeJsonFile } from "@nrwl/devkit";
+import { appRootPath } from "@nrwl/tao/src/utils/app-root";
+
+
+function patchDependencyOfPlugin(
+  pluginDistPath: string,
+  dependencyPackageName: string,
+  dependencyDistPath: string
+) {
+  const path = join(appRootPath, pluginDistPath, 'package.json');
+  const json = readJsonFile(path);
+  json.dependencies[dependencyPackageName] = `file:${appRootPath}/${dependencyDistPath}`;
+  writeJsonFile(path, json);
+}
+
+/**
+ * Same as https://github.com/nrwl/nx/blob/master/packages/nx-plugin/src/utils/testing-utils/nx-project.ts#L13
+ * But as the original method is not exported, we need to add it here and patch it.
+ */
+function runNxNewCommand(args?: string, silent?: boolean) {
+  const localTmpDir = dirname(tmpProjPath());
+  return execSync(
+    `node ${require.resolve(
+      '@nrwl/tao'
+    )} new proj --nx-workspace-root=${localTmpDir} --no-interactive --skip-install --collection=@nrwl/workspace --npmScope=proj --preset=empty ${args || ''
+    }`,
+    {
+      cwd: localTmpDir,
+      ...(silent ? { stdio: ['ignore', 'ignore', 'ignore'] } : {}),
+    }
+  );
+}
+
+/**
+ * Ensures that a project (and the internal packages it depends on) has been setup in the e2e directory
+ * It will also copy `@nrwl` packages to the e2e directory
+ */
+export function ensureNxProjectWithDeps(
+  npmPackageName?: string,
+  pluginDistPath?: string,
+  dependencies?: { depPkgName: string, depDistPath: string }[]
+): void {
+  ensureDirSync(tmpProjPath());
+  cleanup();
+  runNxNewCommand('', false);
+  patchPackageJsonForPlugin(npmPackageName, pluginDistPath);
+
+  dependencies?.forEach(({ depPkgName, depDistPath }) => {
+    patchDependencyOfPlugin(pluginDistPath, depPkgName, depDistPath);
+  });
+
+  runPackageManagerInstall();
+}

--- a/packages/common/src/lib/testing/e2e/index.ts
+++ b/packages/common/src/lib/testing/e2e/index.ts
@@ -1,3 +1,4 @@
 
 export * from './verdaccio-registry';
 export * from './build-package-publish';
+export * from './ensure-nx-project';


### PR DESCRIPTION
- remove reliance on `verdaccio` to proxy internal deps of plugins