### PR TITLE
feat(nx-micronaut): add install executor + make build depend on it

### DIFF
--- a/e2e/nx-micronaut-e2e/tests/nx-micronaut.spec.ts
+++ b/e2e/nx-micronaut-e2e/tests/nx-micronaut.spec.ts
@@ -36,8 +36,8 @@ describe('nx-micronaut e2e', () => {
       `generate @nxrocks/nx-micronaut:new ${prjName}`
     );
 
-    const resultClean= await runNxCommandAsync(`clean ${prjName}`);
-    expect(resultClean.stdout).toContain(`Executing command: ${isWin ? 'mvnw.bat' : './mvnw'} clean`)
+    const resultBuild= await runNxCommandAsync(`build ${prjName}`);
+    expect(resultBuild.stdout).toContain(`Executing command: ${isWin ? 'mvnw.bat' : './mvnw'} package`)
 
     expect(() =>
       checkFilesExist(`apps/${prjName}/mvnw`,`apps/${prjName}/pom.xml`, `apps/${prjName}/README.md`)
@@ -65,8 +65,8 @@ describe('nx-micronaut e2e', () => {
       `generate @nxrocks/nx-micronaut:new ${prjName} --projectType default --buildSystem=${buildSystem} --basePackage=${basePackage} --features=${features}`
     );
 
-    const resultClean= await runNxCommandAsync(`clean ${prjName}`);
-    expect(resultClean.stdout).toContain(`Executing command: ${isWin ? 'mvnw.bat' : './mvnw'} clean`)
+    const resultBuild= await runNxCommandAsync(`build ${prjName}`);
+    expect(resultBuild.stdout).toContain(`Executing command: ${isWin ? 'mvnw.bat' : './mvnw'} package`)
 
     expect(() =>
       checkFilesExist(
@@ -100,8 +100,8 @@ describe('nx-micronaut e2e', () => {
         `generate @nxrocks/nx-micronaut:new ${prjName} --projectType default --buildSystem GRADLE`
       );
 
-      const resultClean= await runNxCommandAsync(`clean ${prjName}`);
-      expect(resultClean.stdout).toContain(`Executing command: ${isWin ? 'gradlew.bat' : './gradlew'} clean`)
+      const resultBuild= await runNxCommandAsync(`build ${prjName}`);
+      expect(resultBuild.stdout).toContain(`Executing command: ${isWin ? 'gradlew.bat' : './gradlew'} build`)
   
       expect(() =>
       checkFilesExist(`apps/${prjName}/gradlew`,`apps/${prjName}/build.gradle`, `apps/${prjName}/README.md`)
@@ -128,8 +128,8 @@ describe('nx-micronaut e2e', () => {
         `generate @nxrocks/nx-micronaut:new ${prjName} --projectType default --buildSystem GRADLE_KOTLIN`
       );
 
-      const resultClean= await runNxCommandAsync(`clean ${prjName}`);
-      expect(resultClean.stdout).toContain(`Executing command: ${isWin ? 'gradlew.bat' : './gradlew'} clean`)
+      const resultBuild= await runNxCommandAsync(`build ${prjName}`);
+      expect(resultBuild.stdout).toContain(`Executing command: ${isWin ? 'gradlew.bat' : './gradlew'} build`)
   
       expect(() =>
       checkFilesExist(`apps/${prjName}/gradlew`,`apps/${prjName}/build.gradle.kts`, `apps/${prjName}/README.md`)

--- a/packages/nx-micronaut/README.md
+++ b/packages/nx-micronaut/README.md
@@ -141,6 +141,7 @@ Here the list of available executors:
 | `run` \| `dev` \| `serve`| `ignoreWrapper:boolean`, `args: string[]`  | Runs the project in dev mode using either `./mvnw\|mvn micronaut:dev` or `./gradlew\|gradle micronautDev` |
 | `dockerfile`    | `ignoreWrapper:boolean`, `args: string[]`  | Generates a `Dockerfile` depending on the `packaging` and `micronaut.runtime properties` using either `./mvnw\|mvn micronaut:dockerfile` or `./gradlew\|gradle dockerfile` |
 | `build`         | `ignoreWrapper:boolean`, `args: string[]`  | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle build` |
+| `install`       | `ignoreWrapper:boolean`, `args: string[]`  | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
 | `test`          | `ignoreWrapper:boolean`, `args: string[]`  | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test` |
 | `clean`         | `ignoreWrapper:boolean`, `args: string[]`  | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean` |
 | `format`        | `ignoreWrapper:boolean`, `args: string[]`  | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle |
@@ -198,6 +199,12 @@ nx dev your-micronaut-app
 
 ```
 nx build your-miconaut-app
+```
+
+### Install the project's artifacts to local Maven repository (in ~/.m2/repository) -  ('install' Executor)
+
+```
+nx install your-quarkus-app
 ```
 
 ### Generating the project dockerfile - ('dockerfile' Executor)

--- a/packages/nx-micronaut/executors.json
+++ b/packages/nx-micronaut/executors.json
@@ -55,6 +55,11 @@
       "schema": "./src/executors/build/schema.json",
       "description": "Executor to build the project"
     },
+    "install": {
+      "implementation": "./src/executors/install/executor",
+      "schema": "./src/executors/install/schema.json",
+      "description": "Executor to install the project's artifacts (i.e jar or war) to the local Maven repository"
+    },
     "aotSampleConfig": {
       "implementation": "./src/executors/aot-sample-config/executor",
       "schema": "./src/executors/aot-sample-config/schema.json",

--- a/packages/nx-micronaut/src/core/constants.ts
+++ b/packages/nx-micronaut/src/core/constants.ts
@@ -7,6 +7,7 @@ export const GRADLE_MICRONAUT_COMMAND_MAPPER : BuilderCommandAliasMapper = {
     'format': 'spotlessApply',
     'format-check': 'spotlessCheck',
     'build': 'build',
+    'install': 'publishToMavenLocal',
     'aotSampleConfig': 'createAotSampleConfigurationFiles',
     'dockerfile': 'dockerfile'
 }
@@ -20,6 +21,7 @@ export const MAVEN_MICRONAUT_COMMAND_MAPPER: BuilderCommandAliasMapper = {
     'format': 'spotless:apply',
     'format-check': 'spotless:check',
     'build': 'package',
+    'install': 'install',
     'aotSampleConfig': 'mn:aot-sample-config',
     'dockerfile': 'mn:dockerfile'
 }

--- a/packages/nx-micronaut/src/executors/install/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/install/executor.spec.ts
@@ -1,0 +1,47 @@
+import { logger } from '@nrwl/devkit';
+import { mocked } from 'jest-mock';
+
+import { installExecutor } from './executor';
+import { InstallExecutorOptions } from './schema';
+import { GRADLE_WRAPPER_EXECUTABLE, MAVEN_WRAPPER_EXECUTABLE_LEGACY, NX_QUARKUS_PKG } from '@nxrocks/common';
+import { expectExecutorCommandRanWith, mockExecutorContext } from '@nxrocks/common/testing';
+
+//first, we mock
+jest.mock('child_process');
+jest.mock('@nrwl/workspace/src/utils/fileutils');
+
+//then, we import
+import * as fsUtility from '@nrwl/workspace/src/utils/fileutils';
+import * as cp from 'child_process';
+
+const mockContext = mockExecutorContext(NX_QUARKUS_PKG, 'install');
+const options: InstallExecutorOptions = {
+  root: 'apps/bootapp'
+};
+
+describe('Install Executor', () => {
+
+  beforeEach(async () => {
+    jest.spyOn(logger, 'info');
+    jest.spyOn(cp, 'execSync');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it.each`
+    ignoreWrapper | buildSystem | buildFile         | execute
+    ${true}       | ${'maven'}  | ${'pom.xml'}      | ${'mvn install '}
+    ${true}       | ${'gradle'} | ${'build.gradle'} | ${'gradle publishToMavenLocal '}
+    ${false}      | ${'maven'}  | ${'pom.xml'}      | ${MAVEN_WRAPPER_EXECUTABLE_LEGACY + ' install '}
+    ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishToMavenLocal '}
+  `('should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper', async ({ ignoreWrapper, buildFile, execute }) => {
+    mocked(fsUtility.fileExists).mockImplementation((filePath: string) => filePath.indexOf(buildFile) !== -1);
+
+    await installExecutor({ ...options, ignoreWrapper }, mockContext);
+
+    expectExecutorCommandRanWith(execute, mockContext, options);
+  });
+
+});

--- a/packages/nx-micronaut/src/executors/install/executor.ts
+++ b/packages/nx-micronaut/src/executors/install/executor.ts
@@ -1,0 +1,11 @@
+import { ExecutorContext } from '@nrwl/devkit'
+import * as path from 'path'
+import { InstallExecutorOptions } from './schema'
+import { runMicronautPluginCommand } from '../../utils/micronaut-utils'
+
+export async function installExecutor(options: InstallExecutorOptions, context: ExecutorContext){
+  const root = path.resolve(context.root, options.root);
+  return runMicronautPluginCommand('install', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
+}
+
+export default installExecutor;

--- a/packages/nx-micronaut/src/executors/install/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/install/schema.d.ts
@@ -1,0 +1,6 @@
+
+export interface InstallExecutorOptions {
+    root: string;
+    ignoreWrapper?: boolean;
+    args?: string[];
+}

--- a/packages/nx-micronaut/src/executors/install/schema.json
+++ b/packages/nx-micronaut/src/executors/install/schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "Install  executor",
+  "description": "",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "root": {
+      "description": "The project root",
+      "type": "string"
+    },
+    "ignoreWrapper": {
+      "description": "Whether or not to use the embedded wrapper (`mvnw`or `gradlew`) to perfom build operations",
+      "type": "boolean",
+      "default": false
+    },
+    "args": {
+      "description": "The argument to be passed to the underlying Quarkus command",
+      "type": "array",
+      "default": []
+    }
+  },
+  "required": []
+}

--- a/packages/nx-micronaut/src/generators/project/lib/add-maven-publish-plugin.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/add-maven-publish-plugin.ts
@@ -1,0 +1,56 @@
+import {
+    logger,
+    Tree
+} from '@nrwl/devkit';
+import { addGradlePlugin, stripIndent } from '@nxrocks/common';
+import { NormalizedSchema } from '../schema';
+
+export function addMavenPublishPlugin(tree: Tree, options: NormalizedSchema) {
+    if (options.buildSystem === 'GRADLE' || options.buildSystem === 'GRADLE_KOTLIN') {
+        logger.debug(`Adding 'maven-publish' plugin...`);
+
+        let language: 'java' | 'groovy' | 'kotlin';
+        switch(options.language) {
+            case 'JAVA':
+                language = 'java';
+                break;
+            case 'GROOVY':
+                language = 'groovy';
+                break;
+            case 'KOTLIN':
+                language = 'kotlin';
+                break;
+            default:
+                language = 'java';
+        }
+
+        addGradlePlugin(tree, options.projectRoot, language, 'maven-publish', undefined, options.buildSystem === 'GRADLE_KOTLIN');
+
+        const artifactSource = 'jar';
+        const publishing = options.buildSystem === 'GRADLE_KOTLIN' ?
+        stripIndent`
+        publishing {
+        	publications {
+        		create<MavenPublication>("mavenJava") {
+        			artifact(tasks.getByName("${artifactSource}"))
+        		}
+        	}
+        }
+        `
+        :
+        stripIndent`
+        publishing {
+        	publications {
+        		mavenJava(MavenPublication) {
+        			artifact ${artifactSource}
+        		}
+        	}
+        }
+        `;
+
+        const ext = options.buildSystem === 'GRADLE_KOTLIN' ? '.kts' : '';
+        const buildGradlePath = `${options.projectRoot}/build.gradle${ext}`;
+        const content = tree.read(buildGradlePath, 'utf-8') + '\n' + publishing;
+        tree.write(buildGradlePath, content);
+    }
+}

--- a/packages/nx-micronaut/src/generators/project/lib/index.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/index.ts
@@ -1,2 +1,4 @@
  export { generateMicronautProject } from './generate-micronaut-project';
+ export { addFormattingWithSpotless } from './add-formatting-with-spotless';
+ export { addMavenPublishPlugin } from './add-maven-publish-plugin';
  export { normalizeOptions } from './normalize-options';


### PR DESCRIPTION
This executor publishes project's artifacts (i.e jar file) to local Maven repository (~/.m2/repository).
This allows dependant projects to properly resolve the dependency during their own builds.

Besides, a task dependency was added to build executor, so that Nx will automatically call this install executor
on dependencies, when running the build task from the dependant project, meaning you don't have to worry about it.