### PR TITLE
feat: rename executors to use `kebab-case`

### DIFF
--- a/e2e/nx-flutter-e2e/tests/nx-flutter.spec.ts
+++ b/e2e/nx-flutter-e2e/tests/nx-flutter.spec.ts
@@ -47,10 +47,10 @@ xdescribe('nx-flutter e2e', () => {
       //{ name: 'attach', output: `Attaching ${appName}` },
 
       //build commands
-      { name: 'buildAar', output: `Running Gradle task 'assembleAarDebug'...` },
-      { name: 'buildApk', output: `Built build/app/outputs/flutter-apk/app-release.apk` },
-      { name: 'buildAppbundle', output: `Built build/app/outputs/bundle/release/app-release.aab` },
-      { name: 'buildBundle', output: `Done in` },
+      { name: 'build-aar', output: `Running Gradle task 'assembleAarDebug'...` },
+      { name: 'build-apk', output: `Built build/app/outputs/flutter-apk/app-release.apk` },
+      { name: 'build-appbundle', output: `Built build/app/outputs/bundle/release/app-release.aab` },
+      { name: 'build-bundle', output: `Done in` },
 
       //required an iOS certificate
       //{name: 'buildIos', output: `No valid code signing certificates were found`},

--- a/packages/nx-flutter/README.md
+++ b/packages/nx-flutter/README.md
@@ -108,13 +108,13 @@ Here the list of available executors<sup>1</sup>:
 | `analyze`      | _see `flutter help analyze`_    | Analyze the project's Dart code |
 | `assemble`     | _see `flutter help assemble`_   | Assemble and build Flutter resources |
 | `attach`       | _see `flutter help attach`_     | Attach to a running app |
-| `buildAar`     | _see `flutter help build aar`_  | Build a repository containing an AAR and a POM file |
-| `buildApk`     | _see `flutter help build apk`_  | Build an Android APK file from your app |
-| `buildAppbundle` | _see `flutter help build appbundle`_ | Build an Android App Bundle file from your app |
-| `buildBundle`  | _see `flutter help build bundle`_ | Build the Flutter assets directory from your app |
-| `buildIos`     | _see `flutter help build ios`_  | Build an iOS application bundle (Mac OS X host only) |
+| `build-aar`     | _see `flutter help build aar`_  | Build a repository containing an AAR and a POM file |
+| `build-apk`     | _see `flutter help build apk`_  | Build an Android APK file from your app |
+| `build-appbundle` | _see `flutter help build appbundle`_ | Build an Android App Bundle file from your app |
+| `build-bundle`  | _see `flutter help build bundle`_ | Build the Flutter assets directory from your app |
+| `build-ios`     | _see `flutter help build ios`_  | Build an iOS application bundle (Mac OS X host only) |
 | `buildIosframework` | _see `flutter help build ios-framework`_ | Produces a .framework directory for a Flutter module and its plugins for integration into existing, plain Xcode projects |
-| `buildIpa`     | _see `flutter help build ipa`_  | Build an iOS archive bundle (Mac OS X host only) |
+| `build-ipa`     | _see `flutter help build ipa`_  | Build an iOS archive bundle (Mac OS X host only) |
 | `clean`        | _see `flutter help clean`_      | Delete the `build/` and `dart_tool/` directories |
 | `drive`        | _see `flutter help drive`_      | Run integration tests for the project on an attached device or emulator |
 | `format`       | _see `flutter help format`_     | Format one or more Dart files |
@@ -127,7 +127,7 @@ Here the list of available executors<sup>1</sup>:
 
 <sup>1</sup> : *Actual executors in your `workspace.json` will depend on the type of `flutter` project (`template`), target `platforms` that you choose to generate.*
 
-Each executor is based on an original project-level `flutter` command. The name is just **camelcased** to match executors' naming conventions.
+Each executor is based on an original project-level `flutter` command. The name is just **kebab-cased** to match executors' naming conventions.
 Besides, the arguments accepted by each executor, are the same as the original `flutter` command they are based upon, encapsulated
 under a generic `--args='...'` option.
 
@@ -138,10 +138,10 @@ $ flutter gen-l10n --header "/// my header"
 
 becomes 👉🏾
 
-$ nx genL10n your-flutterapp --args='--header="/// my header"'
+$ nx gen-l10n your-flutterapp --args='--header="/// my header"'
 ```
 
-> Note that the original `flutter` command name (`gen-l10n`) has been camelcased for creating its `nx-flutter` equivalent (`genL10n`)
+> Note that the original `flutter` command name (`gen-l10n`) has been camelcased for creating its `nx-flutter` equivalent (`gen-l10n`)
 
 > Note that the arguments of the original `flutter` command are wrapped under `--args='...'` option in  the `nx-flutter` equivalent
 

--- a/packages/nx-flutter/src/generators/project/generator.spec.ts
+++ b/packages/nx-flutter/src/generators/project/generator.spec.ts
@@ -15,26 +15,26 @@ const appCommands = [
   { key: 'assemble', value: 'assemble' },
   { key: 'attach', value: 'attach' },
   { key: 'drive', value: 'drive' },
-  { key: 'genL10n', value: 'gen-l10n' },
+  { key: 'gen-l10n', value: 'gen-l10n' },
   { key: 'install', value: 'install' },
   { key: 'run', value: 'run' },
 ];
 
 const pluginOrModOnlyCommands = [
-  { key: 'buildAar', value: 'build aar' },
+  { key: 'build-aar', value: 'build aar' },
 ];
 
 const androidOnlyCommands = [
-  { key: 'buildAar', value: 'build aar' },
-  { key: 'buildApk', value: 'build apk' },
-  { key: 'buildAppbundle', value: 'build appbundle' },
-  { key: 'buildBundle', value: 'build bundle' },
+  { key: 'build-aar', value: 'build aar' },
+  { key: 'build-apk', value: 'build apk' },
+  { key: 'build-appbundle', value: 'build appbundle' },
+  { key: 'build-bundle', value: 'build bundle' },
 ];
 
 const iOsOnlyCommands = [
-  { key: 'buildIos', value: 'build ios' },
-  { key: 'buildIosFramework', value: 'build ios-framework' },
-  { key: 'buildIpa', value: 'build ipa' },
+  { key: 'build-ios', value: 'build ios' },
+  { key: 'build-ios-framework', value: 'build ios-framework' },
+  { key: 'build-ipa', value: 'build ipa' },
 ];
 
 describe('application generator', () => {

--- a/packages/nx-flutter/src/generators/project/generator.ts
+++ b/packages/nx-flutter/src/generators/project/generator.ts
@@ -29,7 +29,7 @@ export async function projectGenerator(tree:Tree, options: ProjectGeneratorOptio
         { key: 'assemble', value: 'assemble' },
         { key: 'attach', value: 'attach' },
         { key: 'drive', value: 'drive' },
-        { key: 'genL10n', value: 'gen-l10n' },
+        { key: 'gen-l10n', value: 'gen-l10n' },
         { key: 'install', value: 'install' },
         { key: 'run', value: 'run' },
       )
@@ -37,18 +37,18 @@ export async function projectGenerator(tree:Tree, options: ProjectGeneratorOptio
 
     if(normalizedOptions.platforms?.indexOf('android') != -1) {
       commands.push(
-        {key: 'buildAar', value: 'build aar'},
-        {key: 'buildApk', value: 'build apk'},
-        {key: 'buildAppbundle', value: 'build appbundle'},
-        {key: 'buildBundle', value: 'build bundle'},
+        {key: 'build-aar', value: 'build aar'},
+        {key: 'build-apk', value: 'build apk'},
+        {key: 'build-appbundle', value: 'build appbundle'},
+        {key: 'build-bundle', value: 'build bundle'},
       )
     }
 
     if(normalizedOptions.platforms?.indexOf('ios') != -1) {
       commands.push(
-        {key: 'buildIos', value: 'build ios'},
-        {key: 'buildIosFramework', value: 'build ios-framework'},
-        {key: 'buildIpa', value: 'build ipa'},
+        {key: 'build-ios', value: 'build ios'},
+        {key: 'build-ios-framework', value: 'build ios-framework'},
+        {key: 'build-ipa', value: 'build ipa'},
       )
     }
     

--- a/packages/nx-micronaut/README.md
+++ b/packages/nx-micronaut/README.md
@@ -213,10 +213,10 @@ nx install your-quarkus-app
 nx dockerfile your-micronaut-app"
 ```
 
-### Generating a sample AOT config file - ('aotConfigSample' Executor)
+### Generating a sample AOT config file - ('aot-sample-config' Executor)
 
 ```
-nx aotConfigSample your-micronaut-app"
+nx aot-sample-config your-micronaut-app"
 ```
 
 ### Building the aplication -  ('build' Executor)

--- a/packages/nx-micronaut/executors.json
+++ b/packages/nx-micronaut/executors.json
@@ -60,7 +60,7 @@
       "schema": "./src/executors/install/schema.json",
       "description": "Executor to install the project's artifacts (i.e jar or war) to the local Maven repository"
     },
-    "aotSampleConfig": {
+    "aot-sample-config": {
       "implementation": "./src/executors/aot-sample-config/executor",
       "schema": "./src/executors/aot-sample-config/schema.json",
       "description": "Executor to list extensions in the project"

--- a/packages/nx-micronaut/src/core/constants.ts
+++ b/packages/nx-micronaut/src/core/constants.ts
@@ -8,7 +8,7 @@ export const GRADLE_MICRONAUT_COMMAND_MAPPER : BuilderCommandAliasMapper = {
     'format-check': 'spotlessCheck',
     'build': 'build',
     'install': 'publishToMavenLocal',
-    'aotSampleConfig': 'createAotSampleConfigurationFiles',
+    'aot-sample-config': 'createAotSampleConfigurationFiles',
     'dockerfile': 'dockerfile'
 }
 
@@ -22,7 +22,7 @@ export const MAVEN_MICRONAUT_COMMAND_MAPPER: BuilderCommandAliasMapper = {
     'format-check': 'spotless:check',
     'build': 'package',
     'install': 'install',
-    'aotSampleConfig': 'mn:aot-sample-config',
+    'aot-sample-config': 'mn:aot-sample-config',
     'dockerfile': 'mn:dockerfile'
 }
 

--- a/packages/nx-micronaut/src/executors/aot-sample-config/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/executor.spec.ts
@@ -14,7 +14,7 @@ jest.mock('@nrwl/workspace/src/utils/fileutils');
 import * as fsUtility from '@nrwl/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
 
-const mockContext = mockExecutorContext(NX_MICRONAUT_PKG,'aotSampleConfig');
+const mockContext = mockExecutorContext(NX_MICRONAUT_PKG,'aot-sample-config');
 const options: AotSampleConfigExecutorOptions = {
   root: 'apps/mnapp'
 };

--- a/packages/nx-micronaut/src/executors/aot-sample-config/executor.ts
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/executor.ts
@@ -5,7 +5,7 @@ import { runMicronautPluginCommand } from '../../utils/micronaut-utils'
 
 export async function aotSampleConfigExecutor(options: AotSampleConfigExecutorOptions, context: ExecutorContext){
   const root = path.resolve(context.root, options.root);
-  return runMicronautPluginCommand('aotSampleConfig', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
+  return runMicronautPluginCommand('aot-sample-config', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
 }
 
 export default aotSampleConfigExecutor;

--- a/packages/nx-quarkus/README.md
+++ b/packages/nx-quarkus/README.md
@@ -139,15 +139,15 @@ Here the list of available executors:
 | Executor         | Arguments                                  | Description                                |
 | --------------- | ------------------------------------------ | ------------------------------------------ |
 | `run` \| `dev` \| `serve`| `ignoreWrapper:boolean`, `args: string[]`  | Runs the project in dev mode using either `./mvnw\|mvn quarkus:dev` or `./gradlew\|gradle quarkusDev` |
-| `remoteDev`     | `ignoreWrapper:boolean`, `args: string[]`  | Runs the project in remote dev mode using either `./mvnw\|mvn quarkus:remoteDev` or `./gradlew\|gradle quarkusRemoteDev` |
+| `remote-dev`     | `ignoreWrapper:boolean`, `args: string[]`  | Runs the project in remote dev mode using either `./mvnw\|mvn quarkus:remote-dev` or `./gradlew\|gradle quarkusRemoteDev` |
 | `build`         | `ignoreWrapper:boolean`, `args: string[]`  | Builds a native or container friendly image either `./mvnw\|mvn build` or `./gradlew\|gradle build` |
 | `test`          | `ignoreWrapper:boolean`, `args: string[]`  | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test` |
 | `clean`         | `ignoreWrapper:boolean`, `args: string[]`  | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean` |
 | `format`        | `ignoreWrapper:boolean`, `args: string[]`  | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle |
 | `package`       | `ignoreWrapper:boolean`, `args: string[]`  | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle package` |
 | `install`       | `ignoreWrapper:boolean`, `args: string[]`  | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
-| `addExtension`  | `ignoreWrapper:boolean`, `args: string[]`  | Adds a new extension to the  project using either `./mvnw\|mvn quarkus:add-extension` or `./gradlew\|gradle quarkusAddExtension` |
-| `listExtensions`| `ignoreWrapper:boolean`, `args: string[]`  | Adds a new extension to the  project using either `./mvnw\|mvn quarkus:list-extensions` or `./gradlew\|gradle quarkusListExtensions` |
+| `add-extension`  | `ignoreWrapper:boolean`, `args: string[]`  | Adds a new extension to the  project using either `./mvnw\|mvn quarkus:add-extension` or `./gradlew\|gradle quarkusAddExtension` |
+| `list-extensions`| `ignoreWrapper:boolean`, `args: string[]`  | Adds a new extension to the  project using either `./mvnw\|mvn quarkus:list-extensions` or `./gradlew\|gradle quarkusListExtensions` |
 
 In order to execute the requested command, each executor will use, by default, the embedded `./mvnw` or `./gradlew` executable, that was generated alongside the project.
 If you want to rely on a globally installed `mvn` or `gradle` executable instead, add the `--ignoreWrapper` option to bypass it.
@@ -156,7 +156,7 @@ This can be useful in a CI environment for example, or in a restricted environme
 
 You can pass in additional arguments to the underlying Gradle or Maven, either temporarily (via `--args="..."`). For example:
 ```
-nx remoteDev your-quarkus-app --args="-Dquarkus.live-reload.url=http://my-remote-host:8080"
+nx remote-dev your-quarkus-app --args="-Dquarkus.live-reload.url=http://my-remote-host:8080"
 ```
 
 Or, permanently by editing the related executor in the `workspace.json` file, as such:
@@ -169,8 +169,8 @@ Or, permanently by editing the related executor in the `workspace.json` file, as
       "root": "apps/your-quarkus-app",
       "sourceRoot": "apps/your-quarkus-app/src",
       "targets": {
-        "remoteDev": {
-          "executor": "@nxrocks/nx-quarkus:remoteDev",
+        "remote-dev": {
+          "executor": "@nxrocks/nx-quarkus:remote-dev",
           "options": {
             "root": "apps/your-quarkus-app",
             "args": ["-Dquarkus.live-reload.url=http://my-remote-host:8080"]// your additional args here
@@ -203,14 +203,14 @@ nx dev your-quarkus-app
 nx install your-quarkus-app
 ```
 
-### Running the project in remote dev mode - ('remoteDev' Executor)
+### Running the project in remote dev mode - ('remote-dev' Executor)
 
 ```
 // for a maven-based project
-nx remoteDev your-quarkus-app --args="-Dquarkus.live-reload.url=http://my-remote-host:8080"
+nx remote-dev your-quarkus-app --args="-Dquarkus.live-reload.url=http://my-remote-host:8080"
 
 // for a gradle-based project
-nx remoteDev your-quarkus-app --args="-Dquarkus.live-reload.url=http://my-remote-host:8080"
+nx remote-dev your-quarkus-app --args="-Dquarkus.live-reload.url=http://my-remote-host:8080"
 ```
 
 ### Building the aplication -  ('build' Executor)
@@ -256,16 +256,16 @@ nx package your-quarkus-app
 
 ```
 // for a maven-based project
-nx addExtension your-quarkus-app --args="-Dextensions=resteasy,hibernate-validator"
+nx add-extension your-quarkus-app --args="-Dextensions=resteasy,hibernate-validator"
 
 // for a gradle-based project
-nx addExtension your-quarkus-app --args="--extensions=resteasy,hibernate-validator"
+nx add-extension your-quarkus-app --args="--extensions=resteasy,hibernate-validator"
 ```
 
 ### List Extensions in the  project -  ('List Extensions' Executor)
 
 ```
-nx listExtensions your-quarkus-app
+nx list-extensions your-quarkus-app
 ```
 
 ## Compatibility with Nx

--- a/packages/nx-quarkus/executors.json
+++ b/packages/nx-quarkus/executors.json
@@ -15,7 +15,7 @@
       "schema": "./src/executors/dev/schema.json",
       "description": "Executor to serve the project (alias to 'dev' executor)"
     },
-    "remoteDev": {
+    "remote-dev": {
       "implementation": "./src/executors/remote-dev/executor",
       "schema": "./src/executors/remote-dev/schema.json",
       "description": "Executor to run the project from remote location"
@@ -70,12 +70,12 @@
       "schema": "./src/executors/package/schema.json",
       "description": "Executor to package the project"
     },
-    "addExtension": {
+    "add-extension": {
       "implementation": "./src/executors/add-extension/executor",
       "schema": "./src/executors/add-extension/schema.json",
       "description": "Executor to add an extension to the project"
     },
-    "listExtensions": {
+    "list-extensions": {
       "implementation": "./src/executors/list-extensions/executor",
       "schema": "./src/executors/list-extensions/schema.json",
       "description": "Executor to list extensions in the project"

--- a/packages/nx-quarkus/src/core/constants.ts
+++ b/packages/nx-quarkus/src/core/constants.ts
@@ -2,7 +2,7 @@ import { BuilderCommandAliasMapper, GradleBuilder, MavenBuilder } from '@nxrocks
 
 export const GRADLE_QUARKUS_COMMAND_MAPPER : BuilderCommandAliasMapper = {
     'dev': 'quarkusDev',
-    'remoteDev': 'quarkusRemoteDev',
+    'remote-dev': 'quarkusRemoteDev',
     'test': 'test',
     'clean': 'clean',
     'format': 'spotlessApply',
@@ -10,15 +10,15 @@ export const GRADLE_QUARKUS_COMMAND_MAPPER : BuilderCommandAliasMapper = {
     'build': 'build',
     'install': 'publishToMavenLocal',
     'package': 'package',
-    'addExtension': 'quarkusAddExtension',
-    'listExtensions': 'quarkusListExtensions',
+    'add-extension': 'quarkusAddExtension',
+    'list-extensions': 'quarkusListExtensions',
 }
 
 export const GRADLE_BUILDER = new GradleBuilder(GRADLE_QUARKUS_COMMAND_MAPPER);
 
 export const MAVEN_QUARKUS_COMMAND_MAPPER: BuilderCommandAliasMapper = {
     'dev': 'quarkus:dev',
-    'remoteDev': 'quarkus:remote-dev',
+    'remote-dev': 'quarkus:remote-dev',
     'test': 'test',
     'clean': 'clean',
     'format': 'spotless:apply',
@@ -26,8 +26,8 @@ export const MAVEN_QUARKUS_COMMAND_MAPPER: BuilderCommandAliasMapper = {
     'build': 'package',
     'install': 'install',
     'package': 'package',
-    'addExtension': 'quarkus:add-extension',
-    'listExtensions': 'quarkus:list-extensions',
+    'add-extension': 'quarkus:add-extension',
+    'list-extensions': 'quarkus:list-extensions',
 }
 
 export const MAVEN_BUILDER = new MavenBuilder(MAVEN_QUARKUS_COMMAND_MAPPER);

--- a/packages/nx-quarkus/src/executors/add-extension/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/add-extension/executor.spec.ts
@@ -14,7 +14,7 @@ jest.mock('@nrwl/workspace/src/utils/fileutils');
 import * as fsUtility from '@nrwl/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
 
-const mockContext = mockExecutorContext(NX_QUARKUS_PKG,'addExtension');
+const mockContext = mockExecutorContext(NX_QUARKUS_PKG,'add-extension');
 const options: AddExtensionExecutorOptions = {
   root: 'apps/quarkusapp'
 };

--- a/packages/nx-quarkus/src/executors/add-extension/executor.ts
+++ b/packages/nx-quarkus/src/executors/add-extension/executor.ts
@@ -5,7 +5,7 @@ import { runQuarkusPluginCommand } from '../../utils/quarkus-utils'
 
 export async function addExtensionExecutor(options: AddExtensionExecutorOptions, context: ExecutorContext){
   const root = path.resolve(context.root, options.root);
-  return runQuarkusPluginCommand('addExtension', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
+  return runQuarkusPluginCommand('add-extension', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
 }
 
 export default addExtensionExecutor;

--- a/packages/nx-quarkus/src/executors/list-extensions/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/list-extensions/executor.spec.ts
@@ -14,7 +14,7 @@ jest.mock('@nrwl/workspace/src/utils/fileutils');
 import * as fsUtility from '@nrwl/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
 
-const mockContext = mockExecutorContext(NX_QUARKUS_PKG,'listExtensions');
+const mockContext = mockExecutorContext(NX_QUARKUS_PKG,'list-extensions');
 const options: ListExtensionsExecutorOptions = {
   root: 'apps/quarkusapp'
 };

--- a/packages/nx-quarkus/src/executors/list-extensions/executor.ts
+++ b/packages/nx-quarkus/src/executors/list-extensions/executor.ts
@@ -5,7 +5,7 @@ import { runQuarkusPluginCommand } from '../../utils/quarkus-utils'
 
 export async function listExtensionsExecutor(options: ListExtensionsExecutorOptions, context: ExecutorContext){
   const root = path.resolve(context.root, options.root);
-  return runQuarkusPluginCommand('listExtensions', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
+  return runQuarkusPluginCommand('list-extensions', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
 }
 
 export default listExtensionsExecutor;

--- a/packages/nx-quarkus/src/executors/remote-dev/executor.ts
+++ b/packages/nx-quarkus/src/executors/remote-dev/executor.ts
@@ -5,7 +5,7 @@ import { runQuarkusPluginCommand } from '../../utils/quarkus-utils'
 
 export async function remoteDevExecutor(options: RemoteDevExecutorOptions, context: ExecutorContext){
   const root = path.resolve(context.root, options.root);
-  return runQuarkusPluginCommand('remoteDev', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
+  return runQuarkusPluginCommand('remote-dev', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
 }
 
 export default remoteDevExecutor;

--- a/packages/nx-quarkus/src/generators/project/generator.spec.ts
+++ b/packages/nx-quarkus/src/generators/project/generator.spec.ts
@@ -144,7 +144,7 @@ describe('project generator', () => {
     const projectDir = projectType === 'application' ? 'apps' : 'libs';
     expect(project.root).toBe(`${projectDir}/${options.name}`);
 
-    const commands:BuilderCommandAliasType[] = ['dev', 'remoteDev', 'test', 'clean', 'build', 'format', 'format-check', 'package', 'addExtension', 'listExtensions'];
+    const commands:BuilderCommandAliasType[] = ['dev', 'remote-dev', 'test', 'clean', 'build', 'format', 'format-check', 'package', 'add-extension', 'list-extensions'];
     commands.forEach(cmd => {
       expect(project.targets[cmd].executor).toBe(`${NX_QUARKUS_PKG}:${cmd}`);
       if(cmd === 'build') { 

--- a/packages/nx-quarkus/src/generators/project/generator.ts
+++ b/packages/nx-quarkus/src/generators/project/generator.ts
@@ -9,7 +9,7 @@ export async function projectGenerator(tree: Tree, options: ProjectGeneratorOpti
   const normalizedOptions = normalizeOptions(tree,options);
 
   const targets = {};
-  const commands:BuilderCommandAliasType[] = ['dev', 'remoteDev', 'test', 'clean', 'build', 'install', 'package', 'addExtension', 'listExtensions'];
+  const commands:BuilderCommandAliasType[] = ['dev', 'remote-dev', 'test', 'clean', 'build', 'install', 'package', 'add-extension', 'list-extensions'];
 
   if(!options.skipFormat) {
     commands.push('format', 'format-check');

--- a/packages/nx-spring-boot/README.md
+++ b/packages/nx-spring-boot/README.md
@@ -150,8 +150,8 @@ Here the list of available executors:
 | `format-check`         | `ignoreWrapper:boolean`, `args: string[]`  | Check whether the project is well formatted using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle |
 | `build`          | `ignoreWrapper:boolean`, `args: string[]`  | Packages the project into an executable Jar using either `./mvnw\|mvn package` or `./gradlew\|gradle build` |
 | `install`          | `ignoreWrapper:boolean`, `args: string[]`  | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
-| `buildInfo`<sup>*</sup>     | `ignoreWrapper:boolean`,                   | Generates a `build-info.properties` using either `./mvnw\|mvn spring-boot:build-info` or `./gradlew\|gradle bootBuildInfo` |
-| `buildImage`<sup>*</sup>    | `ignoreWrapper:boolean`, `args: string[]`  | Generates an [OCI Image](https://github.com/opencontainers/image-spec) using either `./mvnw\|mvn spring-boot:build-image` or `./gradlew\|gradle bootBuildImage` |
+| `build-info`<sup>*</sup>     | `ignoreWrapper:boolean`,                   | Generates a `build-info.properties` using either `./mvnw\|mvn spring-boot:build-info` or `./gradlew\|gradle bootBuildInfo` |
+| `build-image`<sup>*</sup>    | `ignoreWrapper:boolean`, `args: string[]`  | Generates an [OCI Image](https://github.com/opencontainers/image-spec) using either `./mvnw\|mvn spring-boot:build-image` or `./gradlew\|gradle bootBuildImage` |
 
 In order to execute the requested command, each executor will use, by default, the embedded `./mvnw` or `./gradlew` executable, that was generated alongside the project.
 If you want to rely on a globally installed `mvn` or `gradle` executable instead, add the `--ignoreWrapper` option to bypass it.
@@ -204,10 +204,10 @@ nx build your-boot-app
 nx install your-boot-app
 ```
 
-### Building the OCI Image -  ('buildImage' Executor)
+### Building the OCI Image -  ('build-image' Executor)
 
 ```
-nx buildImage your-boot-app
+nx build-image your-boot-app
 ```
 You can pass in additional arguments by editing the related section in the `workspace.json` file, as such:
 ```json
@@ -219,8 +219,8 @@ You can pass in additional arguments by editing the related section in the `work
       "root": "apps/you-boot-app",
       "sourceRoot": "apps/you-boot-app/src",
       "targets": {
-        "buildImage": {
-          "executor": "@nxrocks/nx-spring-boot:buildImage",
+        "build-image": {
+          "executor": "@nxrocks/nx-spring-boot:build-image",
           "options": {
             "root": "apps/you-boot-app",
             "args": ["--executor=gcr.io/paketo-buildpacks/executor:base-platform-api-0.3", "--runImage=my-image"]

--- a/packages/nx-spring-boot/executors.json
+++ b/packages/nx-spring-boot/executors.json
@@ -48,12 +48,12 @@
       "schema": "./src/executors/format-check/schema.json",
       "description": "Executor to check if project's files are well formatted using Spotless plugin (alias to 'format-check' executor)"
     },
-    "buildImage": {
+    "build-image": {
       "implementation": "./src/executors/build-image/executor",
       "schema": "./src/executors/build-image/schema.json",
       "description": "Executor to build the project's OCI image"
     },
-    "buildInfo": {
+    "build-info": {
       "implementation": "./src/executors/build-info/executor",
       "schema": "./src/executors/build-info/schema.json",
       "description": "Executor to build the project's build information"

--- a/packages/nx-spring-boot/src/core/constants.ts
+++ b/packages/nx-spring-boot/src/core/constants.ts
@@ -8,8 +8,8 @@ export const GRADLE_BOOT_COMMAND_MAPPER : BuilderCommandAliasMapper = {
     'install': 'publishToMavenLocal',
     'format': 'spotlessApply',
     'format-check': 'spotlessCheck',
-    'buildImage': 'bootBuildImage',
-    'buildInfo': 'bootBuildInfo'
+    'build-image': 'bootBuildImage',
+    'build-info': 'bootBuildInfo'
 }
 
 export const GRADLE_BUILDER = new GradleBuilder(GRADLE_BOOT_COMMAND_MAPPER);
@@ -22,8 +22,8 @@ export const MAVEN_BOOT_COMMAND_MAPPER: BuilderCommandAliasMapper = {
     'install': 'install',
     'format': 'spotless:apply',
     'format-check': 'spotless:check',
-    'buildImage': 'spring-boot:build-image',
-    'buildInfo': 'spring-boot:build-info'
+    'build-image': 'spring-boot:build-image',
+    'build-info': 'spring-boot:build-info'
 }
 
 export const MAVEN_BUILDER = new MavenBuilder(MAVEN_BOOT_COMMAND_MAPPER);

--- a/packages/nx-spring-boot/src/executors/build-image/executor.ts
+++ b/packages/nx-spring-boot/src/executors/build-image/executor.ts
@@ -5,7 +5,7 @@ import { runBootPluginCommand } from '../../utils/boot-utils'
 
 export async function buildImageExecutor(options: BuildImageExecutorOptions, context: ExecutorContext){
   const root = path.resolve(context.root, options.root);
-  return runBootPluginCommand('buildImage', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
+  return runBootPluginCommand('build-image', options.args, { cwd : root, ignoreWrapper: options.ignoreWrapper});
 }
 
 export default buildImageExecutor;

--- a/packages/nx-spring-boot/src/executors/build-info/executor.ts
+++ b/packages/nx-spring-boot/src/executors/build-info/executor.ts
@@ -5,7 +5,7 @@ import { runBootPluginCommand } from '../../utils/boot-utils'
 
 export async function buildInfoExecutor(options: BuildInfoExecutorOptions, context: ExecutorContext){
   const root = path.resolve(context.root, options.root);
-  return runBootPluginCommand('buildInfo', [], { cwd : root, ignoreWrapper: options.ignoreWrapper});
+  return runBootPluginCommand('build-info', [], { cwd : root, ignoreWrapper: options.ignoreWrapper});
 }
 
 export default buildInfoExecutor;

--- a/packages/nx-spring-boot/src/generators/project/generator.spec.ts
+++ b/packages/nx-spring-boot/src/generators/project/generator.spec.ts
@@ -174,7 +174,7 @@ describe('project generator', () => {
     expect(project.root).toBe(`${projectDir}/${options.name}`);
 
     const commands = ['build', 'install', 'format', 'format-check', 'test', 'clean']
-    const appOnlyCommands = ['run', 'serve', 'buildImage', 'buildInfo'];
+    const appOnlyCommands = ['run', 'serve', 'build-image', 'build-info'];
 
     if (projectType === 'application') {
       commands.push(...appOnlyCommands);

--- a/packages/nx-spring-boot/src/generators/project/generator.ts
+++ b/packages/nx-spring-boot/src/generators/project/generator.ts
@@ -10,7 +10,7 @@ export async function projectGenerator(tree: Tree, options: ProjectGeneratorOpti
 
   const targets = {};
   const commands = ['build', 'install', 'test', 'clean'];
-  const appOnlyCommands = ['run', 'serve', 'buildImage', 'buildInfo'];
+  const appOnlyCommands = ['run', 'serve', 'build-image', 'build-info'];
 
   if (options.projectType === 'application') { //only 'application' projects should have 'boot' related commands
     commands.push(...appOnlyCommands);


### PR DESCRIPTION
BREAKING CHANGE: All executors of this plugin now use `kebab-case` over `camelCase` for consistency