### PR TITLE
feat: add proxy support for project generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "private": true,
   "dependencies": {
     "@swc/helpers": "~0.3.3",
+    "hpagent": "^1.0.0",
     "inquirer": "^8.2.0",
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.1",
@@ -94,4 +95,3 @@
     "url": "https://github.com/tinesoft/nxrocks.git"
   }
 }
-

--- a/packages/common/src/lib/core/utils/utils.ts
+++ b/packages/common/src/lib/core/utils/utils.ts
@@ -30,6 +30,10 @@ export function getHttpProxyAgent(proxyUrl?: string): HttpProxyAgent | HttpsProx
 
   const proxy =  (proxyUrl || httpsProxy || HTTPS_PROXY || httpProxy || HTTP_PROXY)?.trim();
 
+  if(proxy){
+    console.log(`The proxy server at '${proxy}' will be used.`);
+  }
+  
   if (proxy?.startsWith('https')) {
     return new HttpsProxyAgent(proxyAgentOpts);
   } else if(proxy?.startsWith('http')){

--- a/packages/common/src/lib/core/utils/utils.ts
+++ b/packages/common/src/lib/core/utils/utils.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { HttpsProxyAgent, HttpProxyAgent } from 'hpagent';
 
 export function getPackageLatestNpmVersion(pkg: string): string {
   try {
@@ -8,4 +9,33 @@ export function getPackageLatestNpmVersion(pkg: string): string {
   } catch (e) {
     return 'latest';
   }
+}
+
+export function getHttpProxyAgent(proxyUrl?: string): HttpProxyAgent | HttpsProxyAgent | undefined {
+  const proxyAgentOpts = {
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+    maxSockets: 256,
+    maxFreeSockets: 256,
+    //scheduling: 'lifo',
+    proxy: proxyUrl
+  };
+
+  const {
+    http_proxy: httpProxy,
+    https_proxy: httpsProxy,
+    HTTP_PROXY,
+    HTTPS_PROXY
+  } = process.env;
+
+  const proxy =  (proxyUrl || httpsProxy || HTTPS_PROXY || httpProxy || HTTP_PROXY)?.trim();
+
+  if (proxy?.startsWith('https')) {
+    return new HttpsProxyAgent(proxyAgentOpts);
+  } else if(proxy?.startsWith('http')){
+    return new HttpProxyAgent(proxyAgentOpts);
+  } else {
+    return undefined
+  }
+
 }

--- a/packages/nx-micronaut/README.md
+++ b/packages/nx-micronaut/README.md
@@ -24,6 +24,7 @@ Here is a list of some of the coolest features of the plugin:
 - ✅ Generation of Micronaut applications based on **Micronaut Launch** API
 - ✅ Building, packaging, testing, etc your Micronaut projects
 - ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
+- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
 - ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Micronaut's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
 - ...
 
@@ -91,8 +92,13 @@ Option                 | Value | Description
 `features`             | `string` | List of features to use (comma-separated). Go to https://micronaut.io/launch to get the ids needed here
 `micronautVersion`     | `current` \| `snapshot` \| `previous`  |Micronaut version to use
 `micronautLaunchUrl`   | `https://launch.micronaut.io`            | URL to the Micronaut Launch instance to use
+`proxyUrl`             |          | The URL of the (corporate) proxy server to use to access Micronaut Launch
 `tags`                 | `string` | Tags to use for linting (comma-separated)
 `directory`            | `string` | Directory where the project is placed
+
+ > **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
+> Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Micronaut Launch to generate the project.
+> Even simpler, you can just define environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY` globally.
 
 ### Linking Projects (`link` generator)
 

--- a/packages/nx-micronaut/src/generators/project/lib/generate-micronaut-project.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/generate-micronaut-project.ts
@@ -4,7 +4,7 @@ import { workspaceRoot } from '@nrwl/workspace/src/utils/app-root';
 import fetch from 'node-fetch';
 import { NormalizedSchema } from '../schema';
 import {  buildMicronautDownloadUrl } from '../../../utils/micronaut-utils';
-import { extractFromZipStream, getPackageLatestNpmVersion, NX_MICRONAUT_PKG } from '@nxrocks/common';
+import { extractFromZipStream, getHttpProxyAgent, getPackageLatestNpmVersion, NX_MICRONAUT_PKG } from '@nxrocks/common';
 
 export async function generateMicronautProject(tree: Tree, options: NormalizedSchema): Promise<void> {
     const downloadUrl = buildMicronautDownloadUrl(options);
@@ -13,11 +13,13 @@ export async function generateMicronautProject(tree: Tree, options: NormalizedSc
 
     const pkgVersion = getPackageLatestNpmVersion(NX_MICRONAUT_PKG);
     const userAgent = `@nxrocks_nx-micronaut/${pkgVersion}`;
+    const proxyAgent = getHttpProxyAgent(options.proxyUrl);
     const opts = {
         headers: {
             'User-Agent': userAgent
-        }
-    }
+        },
+        ...(proxyAgent ? {agent: proxyAgent} : {})
+    };
     const response = await fetch(downloadUrl, opts);
 
     logger.info(`📦 Extracting Micronaut project zip to '${workspaceRoot}/${options.projectRoot}'...`);

--- a/packages/nx-micronaut/src/generators/project/schema.d.ts
+++ b/packages/nx-micronaut/src/generators/project/schema.d.ts
@@ -4,6 +4,7 @@ export interface ProjectGeneratorOptions {
   directory?: string;
 
   micronautLaunchUrl?: string;
+  proxyUrl?: string;
 
   type: 'default' | 'cli' | 'function' | 'grpc' | 'messaging';
   buildSystem: 'MAVEN' | 'GRADLE' | 'GRADLE_KOTLIN';

--- a/packages/nx-micronaut/src/generators/project/schema.json
+++ b/packages/nx-micronaut/src/generators/project/schema.json
@@ -185,6 +185,10 @@
       "default": "https://launch.micronaut.io",
       "description": "The URL to the Micronaut Launch instance to use to generate the project"
     },
+    "proxyUrl": {
+      "type": "string",
+      "description": "The URL of the (corporate) proxy server to use to access Micronaut Launch"
+    },
     "tags": {
       "type": "string",
       "description": "Add tags to the project (used for linting)",

--- a/packages/nx-quarkus/README.md
+++ b/packages/nx-quarkus/README.md
@@ -22,6 +22,7 @@ Here is a list of some of the coolest features of the plugin:
 - ✅ Generation of Quarkus applications/libraries based on **Quarkus app generator** API
 - ✅ Building, packaging, testing, etc your Quarkus projects
 - ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
+- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
 - ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Quarkus's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
 
   ![Nx Quarkus dependency graph](https://raw.githubusercontent.com/tinesoft/nxrocks/develop/images/nx-quarkus-dep-graph.png)
@@ -90,9 +91,14 @@ Option                 | Value | Description
 `skipFormat`           | `boolean` | Do not add the ability to format code (using Spotless plugin)
 `extensions`           | `string` | List of extensions to use (comma-separated). Go to https://code.quarkus.io/api/extensions to get the ids needed here
 `quarkusInitializerUrl` | `https://code.quarkus.io`            | URL to the Quarkus Initializer instance to use
+`proxyUrl`             |          | The URL of the (corporate) proxy server to use to access Quarkus Initializer
 `skipeCodeSamples`     | `string` | Whether or not to include code samples from extensions (when available)
 `tags`                 | `string` | Tags to use for linting (comma-separated)
 `directory`            | `string` | Directory where the project is placed
+
+> **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
+> Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Spring Initializer to generate the project.
+> Even simpler, you can just define environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY` globally.
 
 ### Linking Projects (`link` generator)
 

--- a/packages/nx-quarkus/src/generators/project/lib/generate-quarkus-project.ts
+++ b/packages/nx-quarkus/src/generators/project/lib/generate-quarkus-project.ts
@@ -3,8 +3,8 @@ import { workspaceRoot } from '@nrwl/workspace/src/utils/app-root';
 
 import fetch from 'node-fetch';
 import { NormalizedSchema } from '../schema';
-import {  buildQuarkusDownloadUrl } from '../../../utils/quarkus-utils';
-import { extractFromZipStream, getPackageLatestNpmVersion, NX_QUARKUS_PKG } from '@nxrocks/common';
+import { buildQuarkusDownloadUrl } from '../../../utils/quarkus-utils';
+import { extractFromZipStream, getHttpProxyAgent, getPackageLatestNpmVersion, NX_QUARKUS_PKG } from '@nxrocks/common';
 
 export async function generateQuarkusProject(tree: Tree, options: NormalizedSchema): Promise<void> {
     const downloadUrl = buildQuarkusDownloadUrl(options);
@@ -13,11 +13,13 @@ export async function generateQuarkusProject(tree: Tree, options: NormalizedSche
 
     const pkgVersion = getPackageLatestNpmVersion(NX_QUARKUS_PKG);
     const userAgent = `@nxrocks_nx-quarkus/${pkgVersion}`;
+    const proxyAgent = getHttpProxyAgent(options.proxyUrl);
     const opts = {
         headers: {
             'User-Agent': userAgent
-        }
-    }
+        },
+        ...(proxyAgent ? {agent: proxyAgent} : {})
+    };
     const response = await fetch(downloadUrl, opts);
 
     logger.info(`📦 Extracting Quarkus project zip to '${workspaceRoot}/${options.projectRoot}'...`);

--- a/packages/nx-quarkus/src/generators/project/schema.d.ts
+++ b/packages/nx-quarkus/src/generators/project/schema.d.ts
@@ -5,6 +5,7 @@ export interface ProjectGeneratorOptions {
   directory?: string;
 
   quarkusInitializerUrl?: string;
+  proxyUrl?: string;
 
   buildSystem: 'MAVEN' | 'GRADLE' | 'GRADLE_KOTLIN_DSL';
   groupId?: string;

--- a/packages/nx-quarkus/src/generators/project/schema.json
+++ b/packages/nx-quarkus/src/generators/project/schema.json
@@ -82,6 +82,10 @@
       "default": "https://code.quarkus.io",
       "description": "The URL to the Quarkus Initializer instance to use to generate the project"
     },
+    "proxyUrl": {
+      "type": "string",
+      "description": "The URL of the (corporate) proxy server to use to access Quarkus Initializer"
+    },
     "skipCodeSamples": {
       "type": "boolean",
       "description": "Would you like to include code samples from extensions (when available)?"

--- a/packages/nx-spring-boot/README.md
+++ b/packages/nx-spring-boot/README.md
@@ -22,8 +22,8 @@ Here is a list of some of the coolest features of the plugin:
 - ✅ Generation of Spring Boot applications/libraries based on **Spring Initializr** API
 - ✅ Building, packaging, testing, etc your Spring Boot projects
 - ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
+- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
 - ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Spring Boot's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
-
   ![Nx Spring Boot dependency graph](https://raw.githubusercontent.com/tinesoft/nxrocks/develop/images/nx-spring-boot-dep-graph.png)
   *Example of running the `nx dep-graph` command on a workspace with 2 Spring Boot projects inside*
 
@@ -95,9 +95,14 @@ Option                 | Value | Description
 `skipFormat`           | `boolean` | Do not add the ability to format code (using Spotless plugin)
 `dependencies`         | `string` | List of dependencies to use (comma-separated). Go to https://start.spring.io/dependencies to get the ids needed here
 `springInitializerUrl` | `https://start.spring.io`            | URL to the Spring Initializer instance to use
+`proxyUrl`             |          | The URL of the (corporate) proxy server to use to access Spring Initializr
 `bootVersion`          | `string` | Spring Boot version to use
 `tags`                 | `string` | Tags to use for linting (comma-separated)
 `directory`            | `string` | Directory where the project is placed
+
+> **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
+> Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Spring Initializer to generate the project.
+> Even simpler, you can just define environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY` globally.
 
 ### Linking Projects (`link` generator)
 

--- a/packages/nx-spring-boot/src/generators/project/lib/generate-boot-project.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/generate-boot-project.ts
@@ -4,7 +4,7 @@ import { workspaceRoot } from '@nrwl/workspace/src/utils/app-root';
 import fetch from 'node-fetch';
 import { NormalizedSchema } from '../schema';
 import { buildBootDownloadUrl } from '../../../utils/boot-utils';
-import { extractFromZipStream, getPackageLatestNpmVersion, NX_SPRING_BOOT_PKG } from '@nxrocks/common';
+import { extractFromZipStream, getHttpProxyAgent, getPackageLatestNpmVersion, NX_SPRING_BOOT_PKG } from '@nxrocks/common';
 
 export async function generateBootProject(tree: Tree, options: NormalizedSchema): Promise<void> {
     const downloadUrl = buildBootDownloadUrl(options);
@@ -13,11 +13,13 @@ export async function generateBootProject(tree: Tree, options: NormalizedSchema)
 
     const pkgVersion = getPackageLatestNpmVersion(NX_SPRING_BOOT_PKG);
     const userAgent = `@nxrocks_nx-spring-boot/${pkgVersion}`;
+    const proxyAgent = getHttpProxyAgent(options.proxyUrl);
     const opts = {
         headers: {
             'User-Agent': userAgent
-        }
-    }
+        },
+        ...(proxyAgent ? {agent: proxyAgent} : {})
+    };
     const response = await fetch(downloadUrl, opts);
 
     logger.info(`Extracting Spring Boot project zip to '${workspaceRoot}/${options.projectRoot}'...`);

--- a/packages/nx-spring-boot/src/generators/project/schema.d.ts
+++ b/packages/nx-spring-boot/src/generators/project/schema.d.ts
@@ -5,6 +5,7 @@ export interface ProjectGeneratorOptions {
   directory?: string;
 
   springInitializerUrl?: string;
+  proxyUrl?: string;
 
   buildSystem: 'maven-project' | 'gradle-project';
   language?: 'java' | 'kotlin' | 'groovy';

--- a/packages/nx-spring-boot/src/generators/project/schema.json
+++ b/packages/nx-spring-boot/src/generators/project/schema.json
@@ -168,6 +168,10 @@
       "default": "https://start.spring.io",
       "description": "The URL to the Spring Initializer instance to use to generate the project"
     },
+    "proxyUrl": {
+      "type": "string",
+      "description": "The URL of the (corporate) proxy server to use to access Spring Initializr"
+    },
     "bootVersion": {
       "type": "string",
       "description": "Spring Boot version"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,6 +4467,11 @@ hosted-git-info@^5.0.0:
   dependencies:
     lru-cache "^7.5.1"
 
+hpagent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-1.0.0.tgz#c68f68b3df845687dbdc4896546713ce09cc6bee"
+  integrity sha512-SCleE2Uc1bM752ymxg8QXYGW0TWtAV4ZW3TqH1aOnyi6T6YW2xadCcclm5qeVjvMvfQ2RKNtZxO7uVb9CTPt1A==
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"


### PR DESCRIPTION
This means generating a project while connected behind a (corporate) proxy now works out-of-the-box.