### PR TITLE
feat: nx flutter support for flutter version manager (fvm)

### DIFF
--- a/packages/nx-flutter/src/generators/project/generator.ts
+++ b/packages/nx-flutter/src/generators/project/generator.ts
@@ -53,7 +53,7 @@ export async function projectGenerator(tree:Tree, options: ProjectGeneratorOptio
     targets[command.key] = {
       executor: `nx:run-commands`,
       options: {
-        command: `flutter ${command.value}`,
+        command: `${normalizedOptions.fvm == true ? 'fvm ': ''}flutter ${command.value}`,
         cwd: normalizedOptions.projectRoot
       },
       ...( command.key.startsWith('build-') ? {outputs: [`{workspaceRoot}/${normalizedOptions.projectRoot}/build`]}: {})

--- a/packages/nx-flutter/src/generators/project/lib/generate-project.ts
+++ b/packages/nx-flutter/src/generators/project/lib/generate-project.ts
@@ -10,12 +10,12 @@ export async function generateFlutterProject(tree: Tree, options: NormalizedSche
 
     logger.info(`Generating Flutter project with following options : ${opts}...`);
 
-    if (!isFlutterInstalled()) {
+    if (!isFlutterInstalled(options.fvm)) {
         throw new Error("'flutter' was not found on your system's PATH.\nPlease make sure you have installed it correctly.\n👉🏾 https://flutter.dev/docs/get-started/install");
       }
     
     // Create the command to execute
-    const execute = `flutter create ${opts} ${options.projectRoot}`;
+    const execute = `${options.fvm == true ? 'fvm ': ''}flutter create ${opts} ${options.projectRoot}`;
     try {
         logger.info(`Executing command: ${execute}`);
         execSync(execute, { stdio: [0, 1, 2] });

--- a/packages/nx-flutter/src/generators/project/lib/prompt-additional-options.ts
+++ b/packages/nx-flutter/src/generators/project/lib/prompt-additional-options.ts
@@ -2,12 +2,18 @@ import { Tree } from '@nrwl/devkit';
 import { prompt } from 'enquirer';
 import { AndroidLanguageType, IosLanguageType, NormalizedSchema, PlatformType } from '../schema';
 
-type PromptResultType = { platforms: PlatformType[], androidLanguage?: AndroidLanguageType, iosLanguage?: IosLanguageType };
+type PromptResultType = { platforms: PlatformType[], androidLanguage?: AndroidLanguageType, iosLanguage?: IosLanguageType, fvm: boolean };
 
 export async function promptAdditionalOptions(tree: Tree, options: NormalizedSchema) {
     if (process.env.NX_INTERACTIVE === 'true') {
 
-        await prompt([{
+        await prompt([
+          {
+            name: 'fvm',
+            type: 'confirm',
+            message: 'Are you using Flutter Version Manager (fvm)?'
+          },
+          {
             skip: ['app', 'plugin'].indexOf(options.template) === -1,
             name: 'platforms',
             type: 'multiselect',
@@ -79,6 +85,7 @@ export async function promptAdditionalOptions(tree: Tree, options: NormalizedSch
                     message: "Which iOS language would you like to use?",
                 }
             ]);
+            options.fvm = result?.fvm;
             options.platforms = result?.platforms;
             options.androidLanguage = languages?.androidLanguage;
             options.iosLanguage = languages?.iosLanguage;

--- a/packages/nx-flutter/src/generators/project/schema.d.ts
+++ b/packages/nx-flutter/src/generators/project/schema.d.ts
@@ -16,6 +16,7 @@ export interface ProjectGeneratorOptions {
   sample?:string;
   platforms?: PlatformType[];
 
+  fvm?: boolean;
   pub?: boolean;
   offline?:boolean;
   tags?: string;

--- a/packages/nx-flutter/src/utils/flutter-utils.ts
+++ b/packages/nx-flutter/src/utils/flutter-utils.ts
@@ -4,9 +4,9 @@ import { getProjectFilePath } from '@nxrocks/common';
 import { execSync } from 'child_process'
 import { NormalizedSchema } from '../generators/project/schema';
 
-export function isFlutterInstalled(): boolean {
+export function isFlutterInstalled(useFVM = false): boolean {
     try {
-        execSync('flutter --version', {  stdio: ['ignore', 'ignore', 'ignore'] });
+        execSync(`${useFVM == true ? 'fvm ' : ''}flutter --version`, {  stdio: ['ignore', 'ignore', 'ignore'] });
         return true;
     } catch (e) {
         return false;


### PR DESCRIPTION
# Plugin NX Flutter

Adds support for [Flutter Version Manager (`fvm`)](https://fvm.app/)

Currently if you're using [Flutter Version Manager (`fvm`)](https://fvm.app/) then using the `yarn nx g @nxrocks/nx-flutter:create project` will fail (see below)

![CleanShot 2023-03-21 at 19 49 07@2x](https://user-images.githubusercontent.com/641367/226824627-e4d84429-bbf4-40d6-8eed-1bfb8a5a8ce9.png)


This adds a prompt and option for using `fvm` instead of the `flutter` path directly
