### PR TITLE
feat: add support for creating Maven/Gradle multi-modules projects

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,8 @@
 				"nrwl.angular-console",
 				"esbenp.prettier-vscode",
 				"dbaeumer.vscode-eslint",
-				"firsttris.vscode-jest-runner"
+				"firsttris.vscode-jest-runner",
+				"anweber.reveal-button"
 			]
 		}
 	}

--- a/e2e/nx-flutter-e2e/tests/nx-flutter.spec.ts
+++ b/e2e/nx-flutter-e2e/tests/nx-flutter.spec.ts
@@ -16,7 +16,7 @@ describe('nx-flutter e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`npm install @nxrocks/nx-flutter@0.0.0-e2e`, {
+    execSync(`pnpm install @nxrocks/nx-flutter@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/nx-flutter-e2e/tests/nx-flutter.spec.ts
+++ b/e2e/nx-flutter-e2e/tests/nx-flutter.spec.ts
@@ -16,7 +16,7 @@ describe('nx-flutter e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`npm install @nxrocks/nx-flutter@e2e`, {
+    execSync(`npm install @nxrocks/nx-flutter@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/nx-ktor-e2e/tests/nx-ktor.spec.ts
+++ b/e2e/nx-ktor-e2e/tests/nx-ktor.spec.ts
@@ -16,7 +16,7 @@ describe('nx-ktor e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`pnpm install @nxrocks/nx-ktor@e2e`, {
+    execSync(`pnpm install @nxrocks/nx-ktor@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/nx-melos-e2e/tests/nx-melos.spec.ts
+++ b/e2e/nx-melos-e2e/tests/nx-melos.spec.ts
@@ -10,7 +10,7 @@ describe('nx-melos e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`pnpm install @nxrocks/nx-melos@e2e`, {
+    execSync(`pnpm install @nxrocks/nx-melos@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/nx-micronaut-e2e/tests/nx-micronaut.spec.ts
+++ b/e2e/nx-micronaut-e2e/tests/nx-micronaut.spec.ts
@@ -17,7 +17,7 @@ describe('nx-micronaut e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`pnpm install @nxrocks/nx-micronaut@e2e`, {
+    execSync(`pnpm install @nxrocks/nx-micronaut@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/nx-quarkus-e2e/tests/nx-quarkus.spec.ts
+++ b/e2e/nx-quarkus-e2e/tests/nx-quarkus.spec.ts
@@ -18,7 +18,7 @@ describe('nx-quarkus e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`pnpm install @nxrocks/nx-quarkus@e2e`, {
+    execSync(`pnpm install @nxrocks/nx-quarkus@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/nx-spring-boot-e2e/tests/nx-spring-boot.spec.ts
+++ b/e2e/nx-spring-boot-e2e/tests/nx-spring-boot.spec.ts
@@ -15,7 +15,7 @@ describe('nx-spring-boot e2e', () => {
 
     // The plugin has been built and published to a local registry in the jest globalSetup
     // Install the plugin built with the latest source code into the test repo
-    execSync(`pnpm install @nxrocks/nx-spring-boot@e2e`, {
+    execSync(`pnpm install @nxrocks/nx-spring-boot@0.0.0-e2e`, {
       cwd: projectDirectory,
       stdio: 'inherit',
       env: process.env,

--- a/e2e/smoke/tests/smoke.test.ts
+++ b/e2e/smoke/tests/smoke.test.ts
@@ -47,12 +47,12 @@ describe('nxrocks smoke tests', () => {
   ${'npm'}    | ${'npx --yes create-nx-workspace'}   | ${'npx'}       | ${'npm i'}     | ${'latest'}      | ${'latest'}  
   ${'yarn'}   | ${'yarn create nx-workspace'}        | ${'yarn'}      | ${'yarn add'}  | ${'latest'}      | ${'latest'}  
   ${'pnpm'}   | ${'pnpm dlx create-nx-workspace'}    | ${'pnpm exec'} | ${'pnpm add'}  | ${'latest'}      | ${'latest'}  
-  ${'npm'}    | ${'npx --yes create-nx-workspace'}   | ${'npx'}       | ${'npm i'}     | ${'latest'}      | ${'e2e'}  
-  ${'yarn'}   | ${'yarn create nx-workspace'}        | ${'yarn'}      | ${'yarn add'}  | ${'latest'}      | ${'e2e'}  
-  ${'pnpm'}   | ${'pnpm dlx create-nx-workspace'}    | ${'pnpm exec'} | ${'pnpm add'}  | ${'latest'}      | ${'e2e'}  
-  ${'npm'}    | ${'npx --yes create-nx-workspace'}   | ${'npx'}       | ${'npm i'}     | ${'local'}       | ${'e2e'}     
-  ${'yarn'}   | ${'yarn create nx-workspace'}        | ${'yarn'}      | ${'yarn add'}  | ${'local'}       | ${'e2e'}     
-  ${'pnpm'}   | ${'pnpm dlx create-nx-workspace'}    | ${'pnpm exec'} | ${'pnpm add'}  | ${'local'}       | ${'e2e'}     
+  ${'npm'}    | ${'npx --yes create-nx-workspace'}   | ${'npx'}       | ${'npm i'}     | ${'latest'}      | ${'0.0.0-e2e'}  
+  ${'yarn'}   | ${'yarn create nx-workspace'}        | ${'yarn'}      | ${'yarn add'}  | ${'latest'}      | ${'0.0.0-e2e'}  
+  ${'pnpm'}   | ${'pnpm dlx create-nx-workspace'}    | ${'pnpm exec'} | ${'pnpm add'}  | ${'latest'}      | ${'0.0.0-e2e'}  
+  ${'npm'}    | ${'npx --yes create-nx-workspace'}   | ${'npx'}       | ${'npm i'}     | ${'local'}       | ${'0.0.0-e2e'}     
+  ${'yarn'}   | ${'yarn create nx-workspace'}        | ${'yarn'}      | ${'yarn add'}  | ${'local'}       | ${'0.0.0-e2e'}     
+  ${'pnpm'}   | ${'pnpm dlx create-nx-workspace'}    | ${'pnpm exec'} | ${'pnpm add'}  | ${'local'}       | ${'0.0.0-e2e'}     
 `(`should sucessfully run using '$workspaceVersion' Nx workspace, $pluginVersion plugins version and $pkgManager package manager`, async ({createCommand, runCommand, addCommand, workspaceVersion, pluginVersion }) => {
 
     if(!process.env.CI && !process.env.FORCE_SMOKE_TESTS) {

--- a/packages/common/src/lib/core/jvm/builder-core.interface.ts
+++ b/packages/common/src/lib/core/jvm/builder-core.interface.ts
@@ -21,7 +21,7 @@ export interface BuilderCore {
 
   getExecutable(ignoreWrapper: boolean, useLegacyWrapper: boolean): string;
 
-  getCommand(alias: BuilderCommandAliasType): string;
+  getCommand(alias: BuilderCommandAliasType, options: { cwd: string, ignoreWrapper?: boolean, runFromParentModule?: boolean}): {cwd: string, command: string};
 }
 
 export type BuilderCommandAliasType = keyof BuilderCommandAliasMapper & string; // enforce that the key is a string (default result of keyof would be string|number)

--- a/packages/common/src/lib/core/jvm/gradle-builder.class.ts
+++ b/packages/common/src/lib/core/jvm/gradle-builder.class.ts
@@ -5,9 +5,11 @@ import {
   BuilderCore,
   BuildSystem,
 } from './builder-core.interface';
+import { hasGradleModule, hasGradleWrapper } from './gradle-utils';
+import { basename, resolve } from 'path';
 
 export class GradleBuilder implements BuilderCore {
-  constructor(private commandAliases: BuilderCommandAliasMapper) {}
+  constructor(private commandAliases: BuilderCommandAliasMapper) { }
 
   getBuildSystemType() {
     return BuildSystem.GRADLE;
@@ -17,7 +19,26 @@ export class GradleBuilder implements BuilderCore {
     return ignoreWrapper ? GRADLE_EXECUTABLE : GRADLE_WRAPPER_EXECUTABLE;
   }
 
-  getCommand(alias: BuilderCommandAliasType) {
-    return this.commandAliases[alias];
+  getCommand(alias: BuilderCommandAliasType, options: { cwd: string, ignoreWrapper?: boolean, runFromParentModule?: boolean }) {
+    let additionalArgs = '';
+    let cwd = options.cwd;
+
+    if (!options.ignoreWrapper && !hasGradleWrapper(options.cwd) && !options.runFromParentModule) {
+      throw new Error(`⚠️ You chose not to use the Gradle wrapper from the parent module, but no wrapper was found in current child module`);
+    }
+    
+    if (options.runFromParentModule) {
+      let pathToModule = [];
+      const childModuleName = basename(options.cwd);
+      do {
+        const module = basename(options.cwd);
+        pathToModule = [...pathToModule, module];
+        cwd = resolve(cwd, '..');
+      } while (!hasGradleModule(cwd, childModuleName));
+
+      additionalArgs = `:${pathToModule.join(':')}:`;
+    }
+
+    return { cwd, command: `${additionalArgs}${this.commandAliases[alias]}` };
   }
 }

--- a/packages/common/src/lib/core/jvm/gradle-utils.spec.ts
+++ b/packages/common/src/lib/core/jvm/gradle-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   getGradlePlugin,
   isMultiModuleGradleProject,
   hasGradleModule,
+  addGradleModule,
 } from './gradle-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { stripIndent } from '../utils';
@@ -427,6 +428,46 @@ describe('gradle-utils', () => {
       expect(hasGradleModule(tree, rootFolder, 'library1')).toBe(true);
       expect(hasGradleModule(tree, rootFolder, 'libraryx')).toBe(false);
     });
-  })
+  });
+
+  describe('addGradleModule', ()=>{
+    let tree: Tree;
+    const rootFolder = 'apps/gradleapp';
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    });
+
+    it('should add gradle module when not already present', ()=>{
+      tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
+      tree.write(`./${rootFolder}/settings.gradle`, MULTI_MODULE_SETTINGS_FILE);
+
+      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(false);
+      expect(addGradleModule(tree, rootFolder, 'libraryX', false)).toBe(true);
+      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(true);
+    });
+
+    it('should not add gradle module when already present', ()=>{
+      tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
+      tree.write(`./${rootFolder}/settings.gradle`, MULTI_MODULE_SETTINGS_FILE);
+
+      expect(addGradleModule(tree, rootFolder, 'library1', false)).toBe(false);
+    });
+
+    it('should add kotlin gradle module when not already present', ()=>{
+      tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
+      tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
+
+      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(false);
+      expect(addGradleModule(tree, rootFolder, 'libraryX', true)).toBe(true);
+      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(true);
+    });
+
+    it('should not add kotlin gradle module when already present', ()=>{
+      tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
+      tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
+
+      expect(addGradleModule(tree, rootFolder, 'library1', true)).toBe(false);
+    });
+  });
 });
 

--- a/packages/common/src/lib/core/jvm/gradle-utils.spec.ts
+++ b/packages/common/src/lib/core/jvm/gradle-utils.spec.ts
@@ -7,8 +7,8 @@ import {
   addSpotlessGradlePlugin,
   disableGradlePlugin,
   getGradlePlugin,
-  isMultiModuleGradleProject,
-  hasGradleModule,
+  hasMultiModuleGradleProjectInTree,
+  hasGradleModuleInTree,
   addGradleModule,
 } from './gradle-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -373,7 +373,7 @@ describe('gradle-utils', () => {
     );
   });
 
-  describe('isMultiModuleGradleProject', ()=>{
+  describe('hasMultiModuleGradleProjectInTree', ()=>{
     let tree: Tree;
     const rootFolder = 'apps/gradleapp';
     beforeEach(async () => {
@@ -384,49 +384,49 @@ describe('gradle-utils', () => {
       tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
       tree.write(`./${rootFolder}/settings.gradle`, MULTI_MODULE_SETTINGS_FILE);
 
-      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(true);
+      expect(hasMultiModuleGradleProjectInTree(tree, rootFolder)).toBe(true);
     });
 
     it('should return true on a multi-module gradle kotlin project', ()=>{
       tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
       tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
 
-      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(true);
+      expect(hasMultiModuleGradleProjectInTree(tree, rootFolder)).toBe(true);
     });
 
     it('should return false on non multi-module gradle project', ()=>{
       tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
       tree.write(`./${rootFolder}/settings.gradle`, SETTINGS_FILE);
 
-    expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(false);
+    expect(hasMultiModuleGradleProjectInTree(tree, rootFolder)).toBe(false);
     });
 
     it('should return false on non multi-module gradle kotlin project', ()=>{
       tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
       tree.write(`./${rootFolder}/settings.gradle.kts`, SETTINGS_KTS_FILE);
 
-      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(false);
+      expect(hasMultiModuleGradleProjectInTree(tree, rootFolder)).toBe(false);
     });
 
 
     it('should return false if no build|settings.gradle[.kts] nor settings.gradle[.kts] is found', ()=>{
-      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(false);
+      expect(hasMultiModuleGradleProjectInTree(tree, rootFolder)).toBe(false);
     });
 
     it('should found the gradle module if present', ()=>{
       tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_FILE);
       tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_FILE);
 
-      expect(hasGradleModule(tree, rootFolder, 'library1')).toBe(true);
-      expect(hasGradleModule(tree, rootFolder, 'libraryx')).toBe(false);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'library1')).toBe(true);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'libraryx')).toBe(false);
     });
 
     it('should found the kotlin gradle module if present', ()=>{
       tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
       tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
 
-      expect(hasGradleModule(tree, rootFolder, 'library1')).toBe(true);
-      expect(hasGradleModule(tree, rootFolder, 'libraryx')).toBe(false);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'library1')).toBe(true);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'libraryx')).toBe(false);
     });
   });
 
@@ -441,9 +441,9 @@ describe('gradle-utils', () => {
       tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
       tree.write(`./${rootFolder}/settings.gradle`, MULTI_MODULE_SETTINGS_FILE);
 
-      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(false);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'libraryX')).toBe(false);
       expect(addGradleModule(tree, rootFolder, 'libraryX', false)).toBe(true);
-      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(true);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'libraryX')).toBe(true);
     });
 
     it('should not add gradle module when already present', ()=>{
@@ -457,9 +457,9 @@ describe('gradle-utils', () => {
       tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
       tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
 
-      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(false);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'libraryX')).toBe(false);
       expect(addGradleModule(tree, rootFolder, 'libraryX', true)).toBe(true);
-      expect(hasGradleModule(tree, rootFolder, 'libraryX')).toBe(true);
+      expect(hasGradleModuleInTree(tree, rootFolder, 'libraryX')).toBe(true);
     });
 
     it('should not add kotlin gradle module when already present', ()=>{

--- a/packages/common/src/lib/core/jvm/gradle-utils.spec.ts
+++ b/packages/common/src/lib/core/jvm/gradle-utils.spec.ts
@@ -1,4 +1,4 @@
-import { ProjectConfiguration, Tree, addProjectConfiguration } from '@nx/devkit';
+import { Tree } from '@nx/devkit';
 import {
   getGradlePlugins,
   hasGradlePlugin,
@@ -13,8 +13,6 @@ import {
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { stripIndent } from '../utils';
 import { SPOTLESS_GRADLE_PLUGIN_ID } from '.';
-import * as fileUtils from '@nx/workspace/src/utils/fileutils';
-import * as fs from 'fs';
 
 const BUILD_GRADLE_FILE = `plugins {
 	id 'org.springframework.boot' version '2.6.2'
@@ -376,103 +374,58 @@ describe('gradle-utils', () => {
 
   describe('isMultiModuleGradleProject', ()=>{
     let tree: Tree;
-    const projectConfig: ProjectConfiguration = {
-      name: "gradleapp",
-      sourceRoot: "apps/gradleapp",
-      projectType: "application",
-      targets:{},
-      tags: [],
-      root: "apps/gradleapp"
-    };
+    const rootFolder = 'apps/gradleapp';
     beforeEach(async () => {
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      addProjectConfiguration(tree, "gradleapp", projectConfig)
     });
 
     it('should return true on a multi-module gradle project', ()=>{
-      const files = {
-        [`${process.cwd()}/apps/gradleapp/build.gradle`]: BUILD_GRADLE_FILE,
-        [`${process.cwd()}/apps/gradleapp/settings.gradle`]: MULTI_MODULE_SETTINGS_FILE
-      };
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>Object.keys(files).includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: string)=> files[p]);
-      expect(isMultiModuleGradleProject(projectConfig)).toBe(true);
+      tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
+      tree.write(`./${rootFolder}/settings.gradle`, MULTI_MODULE_SETTINGS_FILE);
+
+      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(true);
     });
 
     it('should return true on a multi-module gradle kotlin project', ()=>{
-      const files = {
-        [`${process.cwd()}/apps/gradleapp/build.gradle.kts`]: BUILD_GRADLE_KOTLIN_FILE,
-        [`${process.cwd()}/apps/gradleapp/settings.gradle.kts`]: MULTI_MODULE_SETTINGS_KTS_FILE
-      };
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>Object.keys(files).includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: string)=> files[p]);
-      expect(isMultiModuleGradleProject(projectConfig)).toBe(true);
+      tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
+      tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
+
+      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(true);
     });
 
     it('should return false on non multi-module gradle project', ()=>{
-      const files = {
-        [`${process.cwd()}/apps/gradleapp/build.gradle`]: BUILD_GRADLE_FILE,
-        [`${process.cwd()}/apps/gradleapp/settings.gradle`]: SETTINGS_FILE
-      };
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>Object.keys(files).includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: string)=> files[p]);
-      expect(isMultiModuleGradleProject(projectConfig)).toBe(false);
+      tree.write(`./${rootFolder}/build.gradle`, BUILD_GRADLE_FILE);
+      tree.write(`./${rootFolder}/settings.gradle`, SETTINGS_FILE);
+
+    expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(false);
     });
 
     it('should return false on non multi-module gradle kotlin project', ()=>{
-      const files = {
-        [`${process.cwd()}/apps/gradleapp/build.gradle.kts`]: BUILD_GRADLE_KOTLIN_FILE,
-        [`${process.cwd()}/apps/gradleapp/settings.gradle`]: SETTINGS_KTS_FILE
-      };
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>Object.keys(files).includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: string)=> files[p]);
-      expect(isMultiModuleGradleProject(projectConfig)).toBe(false);
+      tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
+      tree.write(`./${rootFolder}/settings.gradle.kts`, SETTINGS_KTS_FILE);
+
+      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(false);
     });
 
 
     it('should return false if no build|settings.gradle[.kts] nor settings.gradle[.kts] is found', ()=>{
-      jest.spyOn(fileUtils, 'fileExists').mockReturnValue(false);
-      expect(isMultiModuleGradleProject(projectConfig)).toBe(false);
+      expect(isMultiModuleGradleProject(tree, rootFolder)).toBe(false);
     });
 
     it('should found the gradle module if present', ()=>{
-      const files = {
-        [`${process.cwd()}/apps/gradleapp/build.gradle`]: BUILD_GRADLE_FILE,
-        [`${process.cwd()}/apps/gradleapp/settings.gradle`]: MULTI_MODULE_SETTINGS_FILE
-      };
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>Object.keys(files).includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: string)=> files[p]);
-      expect(hasGradleModule(projectConfig, 'library1')).toBe(true);
-      expect(hasGradleModule(projectConfig, 'libraryx')).toBe(false);
+      tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_FILE);
+      tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_FILE);
+
+      expect(hasGradleModule(tree, rootFolder, 'library1')).toBe(true);
+      expect(hasGradleModule(tree, rootFolder, 'libraryx')).toBe(false);
     });
 
     it('should found the kotlin gradle module if present', ()=>{
-      const files = {
-        [`${process.cwd()}/apps/gradleapp/build.gradle.kts`]: BUILD_GRADLE_KOTLIN_FILE,
-        [`${process.cwd()}/apps/gradleapp/settings.gradle.kts`]: MULTI_MODULE_SETTINGS_KTS_FILE
-      };
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>Object.keys(files).includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: string)=> files[p]);
-      expect(hasGradleModule(projectConfig, 'library1')).toBe(true);
-      expect(hasGradleModule(projectConfig, 'libraryx')).toBe(false);
+      tree.write(`./${rootFolder}/build.gradle.kts`, BUILD_GRADLE_KOTLIN_FILE);
+      tree.write(`./${rootFolder}/settings.gradle.kts`, MULTI_MODULE_SETTINGS_KTS_FILE);
+
+      expect(hasGradleModule(tree, rootFolder, 'library1')).toBe(true);
+      expect(hasGradleModule(tree, rootFolder, 'libraryx')).toBe(false);
     });
   })
 });

--- a/packages/common/src/lib/core/jvm/gradle-utils.ts
+++ b/packages/common/src/lib/core/jvm/gradle-utils.ts
@@ -345,3 +345,25 @@ export function hasGradleModule(tree: Tree, rootFolder:string, moduleName: strin
 
   return checkProjectFileContains(settings, opts) || checkProjectFileContains(settings, optsKts);
 }
+
+
+export function addGradleModule(
+  tree: Tree,
+  rootFolder: string,
+  moduleName: string,
+  withKotlinDSL: boolean
+) {
+
+  if(hasGradleModule(tree, rootFolder, moduleName))
+    return false;
+  const ext = withKotlinDSL ? '.gradle.kts' : '.gradle';
+  const settingsGradle = tree.read(`${rootFolder}/settings${ext}`, 'utf-8');
+  
+  let lastIncludeIdx = settingsGradle.lastIndexOf('include');
+  lastIncludeIdx = lastIncludeIdx > 0 ? lastIncludeIdx : settingsGradle.length;
+  const newModule = withKotlinDSL ? `\ninclude("${moduleName}")\n`: `\ninclude '${moduleName}'\n`;
+
+  const newSettingGradle  = settingsGradle.slice(0, lastIncludeIdx) + newModule + settingsGradle.slice(lastIncludeIdx);
+  tree.write(`${rootFolder}/settings${ext}`, newSettingGradle)
+  return true
+}

--- a/packages/common/src/lib/core/jvm/gradle-utils.ts
+++ b/packages/common/src/lib/core/jvm/gradle-utils.ts
@@ -429,19 +429,32 @@ ${withKotlinDSL?  `include("${childModuleName}")` : `include '${childModuleName}
   tree.write(`./${rootFolder}/settings.gradle${withKotlinDSL ? '.kts' : ''}`, settingsGradle);
 }
 
-export function getGradleWrapperFiles(){
+export function getGradleWrapperFiles() {
   return [
     'gradlew',
+    'gradlew.bat',
     'gradlew.cmd',
     'gradle/wrapper/gradle-wrapper.jar',
     'gradle/wrapper/gradle-wrapper.properties'
   ];
 }
 
-export function hasGradleWrapperInTree(tree:Tree, rootFolder: string){
-   return getGradleWrapperFiles().every( file => tree.exists(`./${rootFolder}/${file}`))
+export function hasGradleWrapperInTree(tree: Tree, rootFolder: string) {
+  return hasGradleWrapperWithPredicate((file: string) => tree.exists(`./${rootFolder}/${file}`));
 }
 
-export function hasGradleWrapper(rootFolder: string){
-  return getGradleWrapperFiles().every(file => fileExists(resolve(rootFolder, file)));
+export function hasGradleWrapper(rootFolder: string) {
+  return hasGradleWrapperWithPredicate((file: string) => fileExists(resolve(rootFolder, file)));
+}
+
+function hasGradleWrapperWithPredicate(predicate: (file: string) => boolean) {
+  return [
+    'gradlew',
+    'gradle/wrapper/gradle-wrapper.jar',
+    'gradle/wrapper/gradle-wrapper.properties'
+  ].every(file => predicate(file)) &&
+    [
+      'gradlew.bat',
+      'gradlew.cmd',
+    ].some(file => predicate(file)) ;;
 }

--- a/packages/common/src/lib/core/jvm/gradle-utils.ts
+++ b/packages/common/src/lib/core/jvm/gradle-utils.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nx/devkit';
-import { checkProjectFileContains, getGradleBuildFilesExtension, getGradleBuildFilesExtensionInTree, hasGradleProjectSettings, isGradleProjectSettingsInTree as hasGradleProjectSettingsInTree } from './utils';
+import { checkProjectFileContains, getGradleBuildFilesExtension, getGradleBuildFilesExtensionInTree, hasGradleSettingsFile, isGradleProjectSettingsInTree as hasGradleProjectSettingsInTree } from './utils';
 import { fileExists } from '@nx/workspace/src/utils/fileutils';
 import { resolve } from 'path';
 import { getProjectFileContent } from '../workspace';
@@ -318,7 +318,7 @@ export function hasMultiModuleGradleProjectInTree(tree: Tree, rootFolder: string
 
 export function hasMultiModuleGradleProject(cwd: string){
 
-  if (!hasGradleProjectSettings(cwd))
+  if (!hasGradleSettingsFile(cwd))
     return false;
 
   const extension = getGradleBuildFilesExtension({root: cwd});

--- a/packages/common/src/lib/core/jvm/maven-builder.class.ts
+++ b/packages/common/src/lib/core/jvm/maven-builder.class.ts
@@ -5,6 +5,8 @@ import {
   BuilderCore,
   BuildSystem,
 } from './builder-core.interface';
+import { basename, resolve } from 'path';
+import { hasMavenModule, hasMavenWrapper } from './maven-utils';
 
 export class MavenBuilder implements BuilderCore {
   constructor(private commandAliases: BuilderCommandAliasMapper) {}
@@ -20,7 +22,26 @@ export class MavenBuilder implements BuilderCore {
       return useLegacyWrapper ? MAVEN_WRAPPER_EXECUTABLE_LEGACY : MAVEN_WRAPPER_EXECUTABLE;
   }
 
-  getCommand(alias: BuilderCommandAliasType) {
-    return this.commandAliases[alias];
+  getCommand(alias: BuilderCommandAliasType, options: { cwd: string, ignoreWrapper?: boolean, runFromParentModule?: boolean}) {
+    let additionalArgs = '';
+    let cwd = options.cwd;
+
+    if(!options.ignoreWrapper && !hasMavenWrapper(options.cwd) && !options.runFromParentModule){
+      throw new Error(`⚠️ You chose not to use the Maven wrapper from the parent module, but no wrapper was found in current child module`);
+    }
+    
+    if(options.runFromParentModule){
+      let pathToModule = [];
+      const childModuleName = basename(options.cwd);
+      do {
+        const module = basename(options.cwd);
+        pathToModule = [...pathToModule, module];
+        cwd = resolve(cwd, '..');
+      } while (!hasMavenModule(cwd, childModuleName));
+
+      additionalArgs = `-f ${pathToModule.join('/')} `;
+    }
+
+    return {cwd, command: `${additionalArgs}${this.commandAliases[alias]}`};
   }
 }

--- a/packages/common/src/lib/core/jvm/maven-utils.spec.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.spec.ts
@@ -9,9 +9,9 @@ import {
   SPOTLESS_MAVEN_PLUGIN_VERSION,
   removeMavenPlugin,
   addMavenProperty,
-  isMultiModuleMavenProject,
-  hasMavenModule,
   addMavenModule,
+  hasMavenModuleInTree,
+  hasMultiModuleMavenProjectInTree,
 } from './maven-utils';
 
 
@@ -299,23 +299,23 @@ describe('maven-utils', () => {
 
     it('should return true on a multi-module maven project', ()=>{
       tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML)
-      expect(isMultiModuleMavenProject(tree,rootFolder)).toBe(true);
+      expect(hasMultiModuleMavenProjectInTree(tree,rootFolder)).toBe(true);
     });
 
     it('should return false on non multi-module maven project', ()=>{
       tree.write(`./${rootFolder}/pom.xml`, getPomXmlFile())
-      expect(isMultiModuleMavenProject(tree, rootFolder)).toBe(false);
+      expect(hasMultiModuleMavenProjectInTree(tree, rootFolder)).toBe(false);
     });
 
 
     it('should return false if no pom.xml is found', ()=>{
-      expect(isMultiModuleMavenProject(tree, rootFolder)).toBe(false);
+      expect(hasMultiModuleMavenProjectInTree(tree, rootFolder)).toBe(false);
     });
 
     it('should found the maven module if present', ()=>{
       tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML)
-      expect(hasMavenModule(tree, rootFolder, 'library')).toBe(true);
-      expect(hasMavenModule(tree, rootFolder, 'libraryx')).toBe(false);
+      expect(hasMavenModuleInTree(tree, rootFolder, 'library')).toBe(true);
+      expect(hasMavenModuleInTree(tree, rootFolder, 'libraryx')).toBe(false);
     });
   });
 
@@ -329,9 +329,9 @@ describe('maven-utils', () => {
     it('should add maven module when not already present', ()=>{
       tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML);
 
-      expect(hasMavenModule(tree, rootFolder, 'libraryX')).toBe(false);
+      expect(hasMavenModuleInTree(tree, rootFolder, 'libraryX')).toBe(false);
       expect(addMavenModule(tree, rootFolder, 'libraryX')).toBe(true);
-      expect(hasMavenModule(tree, rootFolder, 'libraryX')).toBe(true);
+      expect(hasMavenModuleInTree(tree, rootFolder, 'libraryX')).toBe(true);
     });
 
     it('should not add maven module when already present', ()=>{

--- a/packages/common/src/lib/core/jvm/maven-utils.spec.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.spec.ts
@@ -11,6 +11,7 @@ import {
   addMavenProperty,
   isMultiModuleMavenProject,
   hasMavenModule,
+  addMavenModule,
 } from './maven-utils';
 
 
@@ -316,5 +317,27 @@ describe('maven-utils', () => {
       expect(hasMavenModule(tree, rootFolder, 'library')).toBe(true);
       expect(hasMavenModule(tree, rootFolder, 'libraryx')).toBe(false);
     });
-  })
+  });
+
+  describe('addMavenModule', ()=>{
+    let tree: Tree;
+    const rootFolder = 'apps/mvnapp';
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    });
+
+    it('should add maven module when not already present', ()=>{
+      tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML);
+
+      expect(hasMavenModule(tree, rootFolder, 'libraryX')).toBe(false);
+      expect(addMavenModule(tree, rootFolder, 'libraryX')).toBe(true);
+      expect(hasMavenModule(tree, rootFolder, 'libraryX')).toBe(true);
+    });
+
+    it('should not add maven module when already present', ()=>{
+      tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML);
+
+      expect(addMavenModule(tree, rootFolder, 'library')).toBe(false);
+    });
+  });
 });

--- a/packages/common/src/lib/core/jvm/maven-utils.spec.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.spec.ts
@@ -1,4 +1,4 @@
-import { ProjectConfiguration, Tree, addProjectConfiguration } from '@nx/devkit';
+import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { addMavenPlugin } from '.';
 import { stripIndent } from '../utils';
@@ -12,8 +12,6 @@ import {
   isMultiModuleMavenProject,
   hasMavenModule,
 } from './maven-utils';
-import * as fileUtils from '@nx/workspace/src/utils/fileutils';
-import * as fs from 'fs';
 
 
 const getPomXmlFile = (
@@ -293,60 +291,30 @@ describe('maven-utils', () => {
 
   describe('isMultiModuleMavenProject', ()=>{
     let tree: Tree;
-    const projectConfig: ProjectConfiguration = {
-      name: "mavenapp",
-      sourceRoot: "apps/mavenapp",
-      projectType: "application",
-      targets:{},
-      tags: [],
-      root: "apps/mvnapp"
-    };
+    const rootFolder = 'apps/mvnapp';
     beforeEach(async () => {
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      addProjectConfiguration(tree, "mavenapp", projectConfig)
     });
 
     it('should return true on a multi-module maven project', ()=>{
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>
-        [
-          `${process.cwd()}/apps/mvnapp/pom.xml`,
-        ].includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockReturnValue(MULTI_MODULE_POM_XML);
-      expect(isMultiModuleMavenProject(projectConfig)).toBe(true);
+      tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML)
+      expect(isMultiModuleMavenProject(tree,rootFolder)).toBe(true);
     });
 
     it('should return false on non multi-module maven project', ()=>{
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>
-        [
-          `${process.cwd()}/apps/mvnapp/pom.xml`,
-        ].includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockReturnValue(getPomXmlFile());
-      expect(isMultiModuleMavenProject(projectConfig)).toBe(false);
+      tree.write(`./${rootFolder}/pom.xml`, getPomXmlFile())
+      expect(isMultiModuleMavenProject(tree, rootFolder)).toBe(false);
     });
 
 
     it('should return false if no pom.xml is found', ()=>{
-      jest.spyOn(fileUtils, 'fileExists').mockReturnValue(false);
-      expect(isMultiModuleMavenProject(projectConfig)).toBe(false);
+      expect(isMultiModuleMavenProject(tree, rootFolder)).toBe(false);
     });
 
     it('should found the maven module if present', ()=>{
-      jest
-      .spyOn(fileUtils, 'fileExists')
-      .mockImplementation((p) =>
-        [
-          `${process.cwd()}/apps/mvnapp/pom.xml`,
-        ].includes(p.toString())
-      );
-      jest.spyOn(fs, 'readFileSync').mockReturnValue(MULTI_MODULE_POM_XML);
-      expect(hasMavenModule(projectConfig, 'library')).toBe(true);
-      expect(hasMavenModule(projectConfig, 'libraryx')).toBe(false);
+      tree.write(`./${rootFolder}/pom.xml`, MULTI_MODULE_POM_XML)
+      expect(hasMavenModule(tree, rootFolder, 'library')).toBe(true);
+      expect(hasMavenModule(tree, rootFolder, 'libraryx')).toBe(false);
     });
   })
 });

--- a/packages/common/src/lib/core/jvm/maven-utils.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.ts
@@ -8,7 +8,7 @@ import {
   removeXmlNode,
   stripIndent,
 } from '../utils';
-import { isMavenProject } from './utils';
+import { isMavenProject, isMavenProjectInTree } from './utils';
 import { getProjectFileContent } from '../workspace';
 
 export const SPOTLESS_MAVEN_PLUGIN_GROUP_ID = 'com.diffplug.spotless';
@@ -321,13 +321,13 @@ export function addSpotlessMavenPlugin(
   );
 }
 
-export function isMultiModuleMavenProject(project: ProjectConfiguration){
+export function isMultiModuleMavenProject(tree: Tree, rootFolder: string){
 
-  if (!isMavenProject(project))
+  if (!isMavenProjectInTree(tree,rootFolder))
     return false;
 
     
-  const pomXmlStr = getProjectFileContent(project, 'pom.xml');
+  const pomXmlStr = tree.read(`./${rootFolder}/pom.xml`, 'utf-8');
   const pomXml = readXml(pomXmlStr);
 
   const modulesXPath = `/project/modules`;
@@ -335,13 +335,12 @@ export function isMultiModuleMavenProject(project: ProjectConfiguration){
   return hasXmlMatching(pomXml, modulesXPath);
 }
 
-export function hasMavenModule(project: ProjectConfiguration, moduleName){
+export function hasMavenModule(tree: Tree, rootFolder: string, moduleName){
 
-  if (!isMultiModuleMavenProject(project))
+  if (!isMultiModuleMavenProject(tree,rootFolder))
     return false;
-
     
-  const pomXmlStr = getProjectFileContent(project, 'pom.xml');
+  const pomXmlStr = tree.read(`./${rootFolder}/pom.xml`, 'utf-8');
   const pomXml = readXml(pomXmlStr);
 
   const moduleXPath = `/project/modules/module/text()[.="${moduleName}"]`;

--- a/packages/common/src/lib/core/jvm/maven-utils.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nx/devkit';
+import { ProjectConfiguration, Tree } from '@nx/devkit';
 import {
   addXmlNode,
   findXmlMatching,
@@ -8,6 +8,8 @@ import {
   removeXmlNode,
   stripIndent,
 } from '../utils';
+import { isMavenProject } from './utils';
+import { getProjectFileContent } from '../workspace';
 
 export const SPOTLESS_MAVEN_PLUGIN_GROUP_ID = 'com.diffplug.spotless';
 export const SPOTLESS_MAVEN_PLUGIN_ARTIFACT_ID = 'spotless-maven-plugin';
@@ -317,4 +319,32 @@ export function addSpotlessMavenPlugin(
     SPOTLESS_MAVEN_PLUGIN_VERSION,
     spotlessConfig
   );
+}
+
+export function isMultiModuleMavenProject(project: ProjectConfiguration){
+
+  if (!isMavenProject(project))
+    return false;
+
+    
+  const pomXmlStr = getProjectFileContent(project, 'pom.xml');
+  const pomXml = readXml(pomXmlStr);
+
+  const modulesXPath = `/project/modules`;
+
+  return hasXmlMatching(pomXml, modulesXPath);
+}
+
+export function hasMavenModule(project: ProjectConfiguration, moduleName){
+
+  if (!isMultiModuleMavenProject(project))
+    return false;
+
+    
+  const pomXmlStr = getProjectFileContent(project, 'pom.xml');
+  const pomXml = readXml(pomXmlStr);
+
+  const moduleXPath = `/project/modules/module/text()[.="${moduleName}"]`;
+
+  return hasXmlMatching(pomXml, moduleXPath);
 }

--- a/packages/common/src/lib/core/jvm/maven-utils.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.ts
@@ -1,4 +1,4 @@
-import { ProjectConfiguration, Tree } from '@nx/devkit';
+import { Tree } from '@nx/devkit';
 import {
   addXmlNode,
   findXmlMatching,
@@ -8,8 +8,7 @@ import {
   removeXmlNode,
   stripIndent,
 } from '../utils';
-import { isMavenProject, isMavenProjectInTree } from './utils';
-import { getProjectFileContent } from '../workspace';
+import { isMavenProjectInTree } from './utils';
 
 export const SPOTLESS_MAVEN_PLUGIN_GROUP_ID = 'com.diffplug.spotless';
 export const SPOTLESS_MAVEN_PLUGIN_ARTIFACT_ID = 'spotless-maven-plugin';
@@ -330,9 +329,9 @@ export function isMultiModuleMavenProject(tree: Tree, rootFolder: string){
   const pomXmlStr = tree.read(`./${rootFolder}/pom.xml`, 'utf-8');
   const pomXml = readXml(pomXmlStr);
 
-  const modulesXPath = `/project/modules`;
+  const modulesXpath = `/project/modules`;
 
-  return hasXmlMatching(pomXml, modulesXPath);
+  return hasXmlMatching(pomXml, modulesXpath);
 }
 
 export function hasMavenModule(tree: Tree, rootFolder: string, moduleName){
@@ -343,7 +342,31 @@ export function hasMavenModule(tree: Tree, rootFolder: string, moduleName){
   const pomXmlStr = tree.read(`./${rootFolder}/pom.xml`, 'utf-8');
   const pomXml = readXml(pomXmlStr);
 
-  const moduleXPath = `/project/modules/module/text()[.="${moduleName}"]`;
+  const modulesXpath = `/project/modules/module/text()[.="${moduleName}"]`;
 
-  return hasXmlMatching(pomXml, moduleXPath);
+  return hasXmlMatching(pomXml, modulesXpath);
+}
+
+export function addMavenModule(
+  tree: Tree,
+  rootFolder: string,
+  moduleName: string,
+) {
+
+  if(hasMavenModule(tree, rootFolder, moduleName))
+    return false;
+  const pomXmlStr = tree.read(`${rootFolder}/pom.xml`, 'utf-8');
+  const pomXml = readXml(pomXmlStr);
+
+  const modulesNode =  findXmlMatching(pomXml, `/project/modules`);;
+
+  addXmlNode(modulesNode, {
+    module: moduleName
+  });
+  tree.write(
+    `${rootFolder}/pom.xml`,
+    pomXml.toString({ prettyPrint: true, indent: '\t' })
+  );
+
+  return true
 }

--- a/packages/common/src/lib/core/jvm/maven-utils.ts
+++ b/packages/common/src/lib/core/jvm/maven-utils.ts
@@ -98,25 +98,24 @@ export function addMavenPlugin(
 
   const pluginNode =
     (configuration || executions) &&
-    (typeof configuration === 'object' || typeof executions === 'object')
+      (typeof configuration === 'object' || typeof executions === 'object')
       ? {
-          plugin: {
-            groupId: groupId,
-            artifactId: artifactId,
-            ...(version && { version: version }),
-            ...(configuration && { configuration: configuration }),
-            ...(executions && { executions: executions }),
-          },
-        }
+        plugin: {
+          groupId: groupId,
+          artifactId: artifactId,
+          ...(version && { version: version }),
+          ...(configuration && { configuration: configuration }),
+          ...(executions && { executions: executions }),
+        },
+      }
       : `<plugin>
             <groupId>${groupId}</groupId>
             <artifactId>${artifactId}</artifactId>
             ${version ? `<version>${version}</version>` : ''}
-            ${
-              configuration
-                ? `<configuration>${configuration}</configuration>`
-                : ''
-            }
+            ${configuration
+        ? `<configuration>${configuration}</configuration>`
+        : ''
+      }
             ${executions ? `<executions>${executions}</executions>` : ''}
         </plugin>`;
 
@@ -270,11 +269,10 @@ export function getMavenSpotlessConfig(
                     <!-- Clean up -->
                     <removeUnusedImports/>
 
-                    <!-- Apply ${
-                      jdkVersion && jdkVersion >= 11
-                        ? 'ktfmt formatter(similar to google-java-format, but for Kotlin)'
-                        : 'ktlint formatter'
-                    } -->
+                    <!-- Apply ${jdkVersion && jdkVersion >= 11
+            ? 'ktfmt formatter(similar to google-java-format, but for Kotlin)'
+            : 'ktlint formatter'
+          } -->
                     ${jdkVersion && jdkVersion >= 11 ? '<ktfmt/>' : '<ktlint/>'}
 
                 </kotlin>`,
@@ -324,9 +322,9 @@ export function addSpotlessMavenPlugin(
   );
 }
 
-export function hasMultiModuleMavenProjectInTree(tree: Tree, rootFolder: string){
+export function hasMultiModuleMavenProjectInTree(tree: Tree, rootFolder: string) {
 
-  if (!isMavenProjectInTree(tree,rootFolder))
+  if (!isMavenProjectInTree(tree, rootFolder))
     return false;
 
   const pomXmlStr = tree.read(`./${rootFolder}/pom.xml`, 'utf-8');
@@ -337,12 +335,12 @@ export function hasMultiModuleMavenProjectInTree(tree: Tree, rootFolder: string)
   return hasXmlMatching(pomXml, modulesXpath);
 }
 
-export function hasMultiModuleMavenProject(cwd: string){
+export function hasMultiModuleMavenProject(cwd: string) {
 
   if (!hasMavenProject(cwd))
     return false;
 
-  const pomXmlStr = getProjectFileContent({root:cwd}, `pom.xml`);
+  const pomXmlStr = getProjectFileContent({ root: cwd }, `pom.xml`);
   const pomXml = readXml(pomXmlStr);
 
   const modulesXpath = `/project/modules`;
@@ -350,11 +348,11 @@ export function hasMultiModuleMavenProject(cwd: string){
   return hasXmlMatching(pomXml, modulesXpath);
 }
 
-export function hasMavenModuleInTree(tree: Tree, rootFolder: string, moduleName: string){
+export function hasMavenModuleInTree(tree: Tree, rootFolder: string, moduleName: string) {
 
-  if (!hasMultiModuleMavenProjectInTree(tree,rootFolder))
+  if (!hasMultiModuleMavenProjectInTree(tree, rootFolder))
     return false;
-    
+
   const pomXmlStr = tree.read(`./${rootFolder}/pom.xml`, 'utf-8');
   const pomXml = readXml(pomXmlStr);
 
@@ -363,12 +361,12 @@ export function hasMavenModuleInTree(tree: Tree, rootFolder: string, moduleName:
   return hasXmlMatching(pomXml, modulesXpath);
 }
 
-export function hasMavenModule(cwd: string, moduleName: string){
+export function hasMavenModule(cwd: string, moduleName: string) {
 
   if (!hasMultiModuleMavenProject(cwd))
     return false;
-    
-  const pomXmlStr = getProjectFileContent({root:cwd}, `pom.xml`);
+
+  const pomXmlStr = getProjectFileContent({ root: cwd }, `pom.xml`);
   const pomXml = readXml(pomXmlStr);
 
   const modulesXpath = `/project/modules/module/text()[.="${moduleName}"]`;
@@ -382,13 +380,13 @@ export function addMavenModule(
   moduleName: string,
 ) {
 
-  if(hasMavenModuleInTree(tree, rootFolder, moduleName))
+  if (hasMavenModuleInTree(tree, rootFolder, moduleName))
     return false;
 
   const pomXmlStr = tree.read(`${rootFolder}/pom.xml`, 'utf-8');
   const pomXml = readXml(pomXmlStr);
 
-  const modulesNode =  findXmlMatching(pomXml, `/project/modules`);;
+  const modulesNode = findXmlMatching(pomXml, `/project/modules`);;
 
   addXmlNode(modulesNode, {
     module: moduleName
@@ -401,7 +399,7 @@ export function addMavenModule(
   return true
 }
 
-export function initMavenParentModule(tree: Tree, rootFolder: string, groupId: string, parentModuleName: string, childModuleName:string, helpComment='', version = 'O.0.1-SNAPSHOT'){
+export function initMavenParentModule(tree: Tree, rootFolder: string, groupId: string, parentModuleName: string, childModuleName: string, helpComment = '', version = 'O.0.1-SNAPSHOT') {
 
   const parentPomXml = `
 ${helpComment}
@@ -422,15 +420,15 @@ ${helpComment}
 </project>
 `;
 
-tree.write(`./${rootFolder}/pom.xml`, parentPomXml);
+  tree.write(`./${rootFolder}/pom.xml`, parentPomXml);
 }
 
-export function getMavenModules(cwd: string){
+export function getMavenModules(cwd: string) {
 
   if (!hasMultiModuleMavenProject(cwd))
     return [];
-    
-  const pomXmlStr = getProjectFileContent({root:cwd}, `pom.xml`);
+
+  const pomXmlStr = getProjectFileContent({ root: cwd }, `pom.xml`);
   const pomXml = readXml(pomXmlStr);
 
   const modulesXpath = `/project/modules/module/text()`;
@@ -438,19 +436,38 @@ export function getMavenModules(cwd: string){
   return findXmlContents(pomXml, modulesXpath);
 }
 
-export function getMavenWrapperFiles(){
+export function getMavenWrapperFiles() {
   return [
     'mvnw',
+    'mvnw.bat',
     'mvnw.cmd',
-    '.mvn/wrapper/maven-wrapper.jar',
-    '.mvn/wrapper/maven-wrapper.properties'
+    '.mvn/wrapper/maven-wrapper.properties',
+    '.mvn/wrapper/MavenWrapperDownloader.class',
+    '.mvn/wrapper/MavenWrapperDownloader.java',
+    '.mvn/wrapper/maven-wrapper.jar'
   ];
 }
 
-export function hasMavenWrapperInTree(tree:Tree, rootFolder: string){
-  return getMavenWrapperFiles().every(file => tree.exists(`./${rootFolder}/${file}`))
+export function hasMavenWrapperInTree(tree: Tree, rootFolder: string) {
+  return hasMavenWrapperWithPredicate((file: string) => tree.exists(`./${rootFolder}/${file}`));
 }
 
-export function hasMavenWrapper(rootFolder: string){
-  return getMavenWrapperFiles().every(file => fileExists(resolve(rootFolder, file)));
+export function hasMavenWrapper(rootFolder: string) {
+  return hasMavenWrapperWithPredicate((file: string) => fileExists(resolve(rootFolder, file)));
+}
+
+function hasMavenWrapperWithPredicate(predicate: (file: string) => boolean) {
+  return [
+    'mvnw',
+    '.mvn/wrapper/maven-wrapper.properties'
+  ].every(file => predicate(file)) &&
+    [
+      'mvnw.bat',
+      'mvnw.cmd',
+    ].some(file => predicate(file)) &&
+    [
+      '.mvn/wrapper/MavenWrapperDownloader.class',
+      '.mvn/wrapper/MavenWrapperDownloader.java',
+      '.mvn/wrapper/maven-wrapper.jar'
+    ].some(file => predicate(file));
 }

--- a/packages/common/src/lib/core/jvm/utils.ts
+++ b/packages/common/src/lib/core/jvm/utils.ts
@@ -87,6 +87,16 @@ export function getGradleBuildFilesExtension(project: ProjectConfiguration): '.g
     : undefined;
 }
 
+export function getGradleBuildFilesExtensionInTree(tree: Tree, rootFolder: string): '.gradle.kts' | '.gradle' | undefined {
+  if (tree.exists(`./${rootFolder}/build.gradle.kts`)) {
+    return '.gradle.kts';
+  }
+
+  return (tree.exists(`./${rootFolder}/build.gradle`)) 
+    ? '.gradle'
+    : undefined;
+}
+
 export const getGradleDependencyIdRegEx = () =>
   /\s*(api|implementation|testImplementation)\s*\(?['"](?<id>[^"']+)['"]\)?/g;
 

--- a/packages/common/src/lib/core/utils/xml-utils.ts
+++ b/packages/common/src/lib/core/utils/xml-utils.ts
@@ -1,3 +1,4 @@
+import { __spreadArrays } from 'tslib';
 import { create, builder } from 'xmlbuilder2';
 import { XMLBuilder } from 'xmlbuilder2/lib/interfaces';
 import { select, SelectedValue, SelectReturnType } from 'xpath';
@@ -79,6 +80,18 @@ export function findXmlContent(
     return node.textContent;
   }
   return node?.toString();
+}
+
+export function findXmlContents(
+  xml: XMLBuilder,
+  xpath: string,
+  ignoreNamespace = true
+): string[] {
+  const nodes = findXmlNodes(xml, xpath, ignoreNamespace);
+  if (Array.isArray(nodes)) {
+    return nodes.map(n=> n.textContent);
+  }
+  return [];
 }
 
 export function hasXmlMatching(

--- a/packages/common/src/lib/core/workspace/dep-graph.ts
+++ b/packages/common/src/lib/core/workspace/dep-graph.ts
@@ -55,7 +55,7 @@ export function addDependenciesForProject(
     );
   }
 
-  rootPkgInfo.dependencies.forEach((depPkgInfo) => {
+  rootPkgInfo.dependencies?.forEach((depPkgInfo) => {
     const depProjectName = workspace.packages[depPkgInfo.packageId];
 
     if (depProjectName) {
@@ -65,6 +65,14 @@ export function addDependenciesForProject(
         joinPathFragments(rootProjectFolder, rootPkgInfo.packageFile)
       );
     }
+  });
+
+  rootPkgInfo.modules?.forEach((childModuleName) => {
+    builder.addStaticDependency(
+      rootProjectName,
+      childModuleName,
+      joinPathFragments(rootProjectFolder, rootPkgInfo.packageFile)
+    );
   });
 }
 

--- a/packages/common/src/lib/core/workspace/models.ts
+++ b/packages/common/src/lib/core/workspace/models.ts
@@ -5,6 +5,7 @@ export interface PackageInfo {
   packageId: string;
   packageFile: string;
   dependencies?: PackageInfo[];
+  modules?: string[]
 }
 
 /**

--- a/packages/common/src/lib/core/workspace/utils.ts
+++ b/packages/common/src/lib/core/workspace/utils.ts
@@ -1,26 +1,25 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 
 import {
   getWorkspaceLayout,
-  ProjectConfiguration,
   Tree,
   workspaceRoot,
 } from '@nx/devkit';
 import { readFileSync } from 'fs';
 
-export function getProjectRoot(project: ProjectConfiguration) {
-  return join(workspaceRoot, project.root);
+export function getProjectRoot(project: {root: string}) {
+  return resolve(workspaceRoot, project.root);
 }
 
 export function getProjectFilePath(
-  project: ProjectConfiguration,
+  project: {root: string},
   relativeFile: string
 ) {
   return join(getProjectRoot(project), ...relativeFile.split(/[/\\]/));
 }
 
 export function getProjectFileContent(
-  project: ProjectConfiguration,
+  project: {root: string},
   relativeFile: string
 ) {
   const filePath = getProjectFilePath(project, relativeFile);

--- a/packages/nx-ktor/README.md
+++ b/packages/nx-ktor/README.md
@@ -22,9 +22,10 @@ Here is a list of some of the coolest features of the plugin:
 
 - ✅ Generation of Ktor applications based on **Ktor Starter** API
 - ✅ Building, packaging, testing, etc your Ktor projects
-- ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
-- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
-- ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Ktor's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
+- ✅ 🆕 Built-in support for creating [**multi-modules**](recipes/README.md#creating-mulit-modules-ktor-projects) Spring Boot projects with both `Maven` and `Gradle`
+- ✅ Built-in support for code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for `Maven` or `Gradle`
+- ✅ Built-in support for **corporate proxies** (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
+- ✅ Integration with Nx's **dependency graph** (through `nx graph` or `nx affected:graph`): this allows you to **visualize** the dependencies of any Ktor's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
 - ...
 
 ## Prerequisite
@@ -79,22 +80,26 @@ Here the list of available generation options :
 | --------- | ------------------------- |
 | `<name>`  | The name of your project. |
 
-| Option                  | Value                                   | Description                                                                                        |
-| ----------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `buildSystem`           | `MAVEN` \| `GRADLE` \| `GRADLE_KTS`     | Build system                                                                                       |
-| `groupId`               | `string`                                | Group Id of the project                                                                            |
-| `artifactId`            | `string`                                | Artifact Id of the project                                                                         |
-| `kotlinVersion`         | `string`                                | Kotlin version to use                                                                              |
-| `engine`                | `NETTY` \| `JETTY` \| `CIO` \| `TOMCAT` | Engine to use to serve the application                                                             |
-| `configurationLocation` | `YAML` \| `HOCON` \| `CODE`             | Configuratin Location to use                                                                       |
-| `skipFormat`            | `boolean`                               | Do not add the ability to format code (using Spotless plugin)                                      |
-| `skipCodeSamples`       | `boolean`                               | Do not generate code samples                                                                       |
-| `features`              | `string`                                | List of features to use (comma-separated). Go to [recipes](recipes/README.md) for more information |
-| `ktorVersion`           | `string`                                | Ktor version to use                                                                                |
-| `ktorInitializrUrl`     | `https://start.ktor.io`                 | URL to the Ktor Start instance to use                                                              |
-| `proxyUrl`              | `string`                                | The URL of the (corporate) proxy server to use to access Ktor Launch                               |
-| `tags`                  | `string`                                | Tags to use for linting (comma-separated)                                                          |
-| `directory`             | `string`                                | Directory where the project is placed                                                              |
+| Option                     | Value                                   | Description                                                                                        |
+| -------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `buildSystem`              | `MAVEN` \| `GRADLE` \| `GRADLE_KTS`     | Build system                                                                                       |
+| `groupId`                  | `string`                                | Group Id of the project                                                                            |
+| `artifactId`               | `string`                                | Artifact Id of the project                                                                         |
+| `kotlinVersion`            | `string`                                | Kotlin version to use                                                                              |
+| `engine`                   | `NETTY` \| `JETTY` \| `CIO` \| `TOMCAT` | Engine to use to serve the application                                                             |
+| `configurationLocation`    | `YAML` \| `HOCON` \| `CODE`             | Configuratin Location to use                                                                       |
+| `skipFormat`               | `boolean`                               | Do not add the ability to format code (using Spotless plugin)                                      |
+| `skipCodeSamples`          | `boolean`                               | Do not generate code samples                                                                       |
+| `features`                 | `string`                                | List of features to use (comma-separated). Go to [recipes](recipes/README.md) for more information |
+| `transformIntoMultiModule` | `boolean`                               | Transform the project into a multi-module project. Go to [recipes](recipes/README.md#creating-mulit-modules-ktor-projects) for more information               |
+| `addToExistingParentModule`| `boolean`                               | Add the project into an existing parent module project. Go to [recipes](recipes/README.md#creating-mulit-modules-ktor-projects) for more information               |
+| `parentModuleName`         | `string`                                | Name of the parent module to create or to add child project into. Go to [recipes](recipes/README.md#creating-mulit-modules-ktor-projects) for more information               |
+| `keepProjectLevelWrapper`  | `boolean`                               | Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Go to [recipes](recipes/README.md#creating-mulit-modules-ktor-projects) for more information               |
+| `ktorVersion`              | `string`                                | Ktor version to use                                                                                |
+| `ktorInitializrUrl`        | `https://start.ktor.io`                 | URL to the Ktor Start instance to use                                                              |
+| `proxyUrl`                 | `string`                                | The URL of the (corporate) proxy server to use to access Ktor Launch                               |
+| `tags`                     | `string`                                | Tags to use for linting (comma-separated)                                                          |
+| `directory`                | `string`                                | Directory where the project is placed                                                              |
 
 > **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
 > Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Ktor Launch to generate the project.
@@ -141,18 +146,18 @@ Once your app is generated, you can now use buidlers to manage it.
 
 Here the list of available executors:
 
-| Executor                     | Arguments                                 | Description                                                                                                                                                         |
-| ---------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run` \| `serve`             | `ignoreWrapper:boolean`, `args: string[]` | Runs the project in dev mode using either `./mvnw\|mvn exec:java` or `./gradlew\|gradle runFatJar`                                                                  |
-| `build`                      | `ignoreWrapper:boolean`, `args: string[]` | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle buildFatJar`                                                                          |
-| `install`                    | `ignoreWrapper:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal`    |
-| `test`                       | `ignoreWrapper:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                       |
-| `clean`                      | `ignoreWrapper:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                    |
-| `format`                     | `ignoreWrapper:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                                |
-| `build-image`                | `ignoreWrapper:boolean`, `args: string[]` | Generates an [OCI Image](https://github.com/opencontainers/image-spec) using either `./mvnw\|mvn docker:build` or `./gradlew\|gradle buildImage`                    |
-| `publish-image`<sup>\*</sup> | `ignoreWrapper:boolean`, `args: string[]` | Builds the project into a Docker image and publishes it to an external registry using either `./mvnw\|mvn docker:push` or `./gradlew\|gradle publishImage`          |
-| `publish-image-locally`      | `ignoreWrapper:boolean`, `args: string[]` | Builds the project into a Docker image and publishes it to local registry using either `./mvnw\|mvn docker:push` or `./gradlew\|gradle publishImageToLocalRegistry` |
-| `run-docker`                 | `ignoreWrapper:boolean`, `args: string[]` | Builds the project into a Docker image and runs it using either `./mvnw\|mvn docker:run` or `./gradlew\|gradle rundDocker`                                          |
+| Executor                     | Arguments                                                                | Description                                                                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run` \| `serve`             | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Runs the project in dev mode using either `./mvnw\|mvn exec:java` or `./gradlew\|gradle runFatJar`                                                                  |
+| `build`                      | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle buildFatJar`                                                                          |
+| `install`                    | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal`    |
+| `test`                       | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                       |
+| `clean`                      | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                    |
+| `format`                     | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                                |
+| `build-image`                | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Generates an [OCI Image](https://github.com/opencontainers/image-spec) using either `./mvnw\|mvn docker:build` or `./gradlew\|gradle buildImage`                    |
+| `publish-image`<sup>\*</sup> | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Builds the project into a Docker image and publishes it to an external registry using either `./mvnw\|mvn docker:push` or `./gradlew\|gradle publishImage`          |
+| `publish-image-locally`      | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Builds the project into a Docker image and publishes it to local registry using either `./mvnw\|mvn docker:push` or `./gradlew\|gradle publishImageToLocalRegistry` |
+| `run-docker`                 | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Builds the project into a Docker image and runs it using either `./mvnw\|mvn docker:run` or `./gradlew\|gradle rundDocker`                                          |
 
 > <sup>\*</sup> Additonal configuration is needed to configure Docker external registry (for [Gradle-based](https://github.com/ktorio/ktor-build-plugins#dockerize-your-application) projects, for [Maven-based](https://dmp.fabric8.io/#docker:push) projects)
 

--- a/packages/nx-ktor/recipes/README.md
+++ b/packages/nx-ktor/recipes/README.md
@@ -18,3 +18,15 @@ You will need to fetch and enter the features ids manually:
 
 3. In Nx Console UI, enter the features ids you want to use, separated by a comma
 ![Adding features in Nx Console](images/nx-console-add-features.png)
+
+## Creating mulit-modules Ktor projects
+
+The support for creating multi-module Ktor project with either `Maven` or `Gradle` was added to the plugin since `v8.1.0`.
+
+When generating a new project, you can now choose either to:
+
+* Transform the project being generated into a multi-module project by setting `transformIntoMultiModule` to `true` and by providing the name of the parent module to create on top of the child project, via `parentModuleName` option.
+* Add the project being generated into an existing multi-module project by setting `addToExistingParentModule` to `true` and by providing the name of the parent module to add the child project too.
+
+> **Note** When running the `@nxrocks/nx-spring-boot:project` generator in **interactive mode** (i.e via command line),
+> we can automatically analyze your workspace and prompt for the appropriate above options to add multi-module support.

--- a/packages/nx-ktor/src/executors/build-image/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/build-image/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 
 import { buildImageExecutor } from './executor';
 import { BuildImageExecutorOptions } from './schema';
@@ -50,7 +50,7 @@ describe('PublishImage Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildImageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/build-image/executor.ts
+++ b/packages/nx-ktor/src/executors/build-image/executor.ts
@@ -11,6 +11,7 @@ export async function buildImageExecutor(
   return runKtorPluginCommand('build-image', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/build-image/schema.d.ts
+++ b/packages/nx-ktor/src/executors/build-image/schema.d.ts
@@ -2,5 +2,6 @@
 export interface BuildImageExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/build-image/schema.json
+++ b/packages/nx-ktor/src/executors/build-image/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/build/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/build/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 
 import { buildExecutor } from './executor';
 import { BuildExecutorOptions } from './schema';
@@ -50,7 +50,7 @@ describe('Build Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/build/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/build/executor.spec.ts
@@ -6,6 +6,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -19,6 +21,7 @@ jest.mock('@nx/workspace/src/utils/fileutils');
 //then, we import
 import * as fsUtility from '@nx/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
+import { mocked } from 'jest-mock';
 
 const mockContext = mockExecutorContext(NX_KTOR_PKG, 'build');
 const options: BuildExecutorOptions = {
@@ -43,9 +46,11 @@ describe('Build Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' buildFatJar '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/build/executor.ts
+++ b/packages/nx-ktor/src/executors/build/executor.ts
@@ -11,6 +11,7 @@ export async function buildExecutor(
   return runKtorPluginCommand('build', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/build/schema.d.ts
+++ b/packages/nx-ktor/src/executors/build/schema.d.ts
@@ -2,5 +2,6 @@
 export interface BuildExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/build/schema.json
+++ b/packages/nx-ktor/src/executors/build/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/check-format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatCheckExecutor } from './executor';
@@ -48,9 +48,9 @@ describe('Format Check Executor', () => {
     'should execute a $buildSystem format check and ignoring wrapper : $ignoreWrapper',
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
 
-      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      const files = [buildFile as string, ...(buildSystem === 'maven' ? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/check-format/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Format Check Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' spotlessCheck '}
   `(
     'should execute a $buildSystem format check and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/check-format/executor.ts
+++ b/packages/nx-ktor/src/executors/check-format/executor.ts
@@ -11,6 +11,7 @@ export async function formatCheckExecutor(
   return runKtorPluginCommand('check-format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/check-format/schema.d.ts
+++ b/packages/nx-ktor/src/executors/check-format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatCheckExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/check-format/schema.json
+++ b/packages/nx-ktor/src/executors/check-format/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/clean/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/clean/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { cleanExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Clean Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven' ? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some((f) => filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/clean/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/clean/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Clean Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' clean '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven' ? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some((f) => filePath.endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/clean/executor.ts
+++ b/packages/nx-ktor/src/executors/clean/executor.ts
@@ -11,6 +11,7 @@ export async function cleanExecutor(
   return runKtorPluginCommand('clean', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/clean/schema.d.ts
+++ b/packages/nx-ktor/src/executors/clean/schema.d.ts
@@ -2,5 +2,6 @@
 export interface CleanExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/clean/schema.json
+++ b/packages/nx-ktor/src/executors/clean/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Maven or Gradle command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/format/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/format/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('FormatJar Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' spotlessApply '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/format/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatExecutor } from './executor';
@@ -48,9 +48,9 @@ describe('FormatJar Executor', () => {
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
 
-      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      const files = [buildFile as string, ...(buildSystem === 'maven' ? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/format/executor.ts
+++ b/packages/nx-ktor/src/executors/format/executor.ts
@@ -11,6 +11,7 @@ export async function formatExecutor(
   return runKtorPluginCommand('format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/format/schema.d.ts
+++ b/packages/nx-ktor/src/executors/format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/format/schema.json
+++ b/packages/nx-ktor/src/executors/format/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/install/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/install/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { installExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Install Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/install/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/install/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Install Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishToMavenLocal '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/install/executor.ts
+++ b/packages/nx-ktor/src/executors/install/executor.ts
@@ -11,6 +11,7 @@ export async function installExecutor(
   return runKtorPluginCommand('install', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/install/schema.d.ts
+++ b/packages/nx-ktor/src/executors/install/schema.d.ts
@@ -2,5 +2,6 @@
 export interface InstallExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/install/schema.json
+++ b/packages/nx-ktor/src/executors/install/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/publish-image-locally/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/publish-image-locally/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 
 import { publishImageLocallyExecutor } from './executor';
 import { PublishImageLocallyExecutorOptions } from './schema';
@@ -50,7 +50,7 @@ describe('PublishImageLocally Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await publishImageLocallyExecutor(

--- a/packages/nx-ktor/src/executors/publish-image-locally/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/publish-image-locally/executor.spec.ts
@@ -6,6 +6,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -19,6 +21,7 @@ jest.mock('@nx/workspace/src/utils/fileutils');
 //then, we import
 import * as fsUtility from '@nx/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
+import { mocked } from 'jest-mock';
 
 const mockContext = mockExecutorContext(NX_KTOR_PKG, 'publish-image');
 const options: PublishImageLocallyExecutorOptions = {
@@ -43,9 +46,11 @@ describe('PublishImageLocally Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishImageToLocalRegistry '}
   `(
     'should execute a $buildSystem publish-image and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await publishImageLocallyExecutor(

--- a/packages/nx-ktor/src/executors/publish-image-locally/executor.ts
+++ b/packages/nx-ktor/src/executors/publish-image-locally/executor.ts
@@ -11,6 +11,7 @@ export async function publishImageLocallyExecutor(
   return runKtorPluginCommand('publish-image-locally', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/publish-image-locally/schema.d.ts
+++ b/packages/nx-ktor/src/executors/publish-image-locally/schema.d.ts
@@ -1,5 +1,6 @@
 export interface PublishImageLocallyExecutorOptions {
   root: string;
   ignoreWrapper?: boolean;
+  runFromParentModule?: boolean;
   args?: string[];
 }

--- a/packages/nx-ktor/src/executors/publish-image-locally/schema.json
+++ b/packages/nx-ktor/src/executors/publish-image-locally/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/publish-image/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/publish-image/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 
 import { publishImageExecutor } from './executor';
 import { PublishImageExecutorOptions } from './schema';
@@ -50,7 +50,7 @@ describe('PublishImage Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await publishImageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/publish-image/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/publish-image/executor.spec.ts
@@ -6,6 +6,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -19,6 +21,7 @@ jest.mock('@nx/workspace/src/utils/fileutils');
 //then, we import
 import * as fsUtility from '@nx/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
+import { mocked } from 'jest-mock';
 
 const mockContext = mockExecutorContext(NX_KTOR_PKG, 'publish-image');
 const options: PublishImageExecutorOptions = {
@@ -43,9 +46,11 @@ describe('PublishImage Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishImage '}
   `(
     'should execute a $buildSystem publish-image and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await publishImageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/publish-image/executor.ts
+++ b/packages/nx-ktor/src/executors/publish-image/executor.ts
@@ -11,6 +11,7 @@ export async function publishImageExecutor(
   return runKtorPluginCommand('publish-image', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/publish-image/schema.d.ts
+++ b/packages/nx-ktor/src/executors/publish-image/schema.d.ts
@@ -2,5 +2,6 @@
 export interface PublishImageExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/publish-image/schema.json
+++ b/packages/nx-ktor/src/executors/publish-image/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/run-docker/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/run-docker/executor.spec.ts
@@ -6,6 +6,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -19,6 +21,7 @@ jest.mock('@nx/workspace/src/utils/fileutils');
 //then, we import
 import * as fsUtility from '@nx/workspace/src/utils/fileutils';
 import * as cp from 'child_process';
+import { mocked } from 'jest-mock';
 
 const mockContext = mockExecutorContext(NX_KTOR_PKG, 'run-docker');
 const options: RunDockerExecutorOptions = {
@@ -43,9 +46,11 @@ describe('RunDocker Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' runDocker '}
   `(
     'should execute a $buildSystem run-docker and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await runDockerExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/run-docker/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/run-docker/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 
 import { runDockerExecutor } from './executor';
 import { RunDockerExecutorOptions } from './schema';
@@ -50,7 +50,7 @@ describe('RunDocker Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await runDockerExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/run-docker/executor.ts
+++ b/packages/nx-ktor/src/executors/run-docker/executor.ts
@@ -11,6 +11,7 @@ export async function runDockerExecutor(
   return runKtorPluginCommand('run-docker', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/run-docker/schema.d.ts
+++ b/packages/nx-ktor/src/executors/run-docker/schema.d.ts
@@ -2,5 +2,6 @@
 export interface RunDockerExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/run-docker/schema.json
+++ b/packages/nx-ktor/src/executors/run-docker/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/run/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/run/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { runExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Run Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await runExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/run/executor.ts
+++ b/packages/nx-ktor/src/executors/run/executor.ts
@@ -11,6 +11,7 @@ export async function runExecutor(
   return runKtorPluginCommand('run', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/run/schema.d.ts
+++ b/packages/nx-ktor/src/executors/run/schema.d.ts
@@ -2,5 +2,6 @@
 export interface RunExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/run/schema.json
+++ b/packages/nx-ktor/src/executors/run/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/serve/schema.json
+++ b/packages/nx-ktor/src/executors/serve/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-ktor/src/executors/test/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/test/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_KTOR_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Test Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' test '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/test/executor.spec.ts
+++ b/packages/nx-ktor/src/executors/test/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { testExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Test Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-ktor/src/executors/test/executor.ts
+++ b/packages/nx-ktor/src/executors/test/executor.ts
@@ -11,6 +11,7 @@ export async function testExecutor(
   return runKtorPluginCommand('test', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-ktor/src/executors/test/schema.d.ts
+++ b/packages/nx-ktor/src/executors/test/schema.d.ts
@@ -2,5 +2,6 @@
 export interface TestExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-ktor/src/executors/test/schema.json
+++ b/packages/nx-ktor/src/executors/test/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Ktor command",
       "type": "array",

--- a/packages/nx-ktor/src/generators/project/generator.spec.ts
+++ b/packages/nx-ktor/src/generators/project/generator.spec.ts
@@ -256,12 +256,12 @@ describe('project generator', () => {
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        1,
+        2,
         `⬇️ Downloading Ktor project zip from : '${downloadUrl}'...`
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        2,
+        3,
         `📦 Extracting Ktor project zip to '${workspaceRoot}/${rootDir}/${options.name}'...`
       );
     }

--- a/packages/nx-ktor/src/generators/project/lib/generate-ktor-project.ts
+++ b/packages/nx-ktor/src/generators/project/lib/generate-ktor-project.ts
@@ -6,6 +6,8 @@ import { buildKtorDownloadUrl } from '../../../utils/ktor-utils';
 import {
   extractFromZipStream,
   getCommonHttpHeaders,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
   NX_KTOR_PKG,
 } from '@nxrocks/common';
 
@@ -42,9 +44,24 @@ export async function generateKtorProject(
         entryPath.endsWith('mvnw') || entryPath.endsWith('gradlew')
           ? '755'
           : undefined;
-      tree.write(`${options.projectRoot}/${entryPath}`, entryContent, {
-        mode: execPermission,
-      });
+        if (getMavenWrapperFiles().includes(entryPath) || getGradleWrapperFiles().includes(entryPath)) {
+          if (options.transformIntoMultiModule) {
+            tree.write(`${options.moduleRoot}/${entryPath}`, entryContent, {
+              mode: execPermission,
+            });
+          }
+          if (options.keepProjectLevelWrapper) {
+            tree.write(`${options.projectRoot}/${entryPath}`, entryContent, {
+              mode: execPermission,
+            });
+          }
+  
+        }
+        else {
+          tree.write(`${options.projectRoot}/${entryPath}`, entryContent, {
+            mode: execPermission,
+          });
+        }
     });
   } else {
     throw new Error(stripIndents`

--- a/packages/nx-ktor/src/generators/project/lib/generate-project-configuration.ts
+++ b/packages/nx-ktor/src/generators/project/lib/generate-project-configuration.ts
@@ -1,0 +1,90 @@
+import { Tree, addProjectConfiguration, logger } from '@nx/devkit';
+import { NormalizedSchema } from '../schema';
+import {
+  BuilderCommandAliasType,
+  NX_KTOR_PKG,
+  NX_MICRONAUT_PKG,
+  NX_QUARKUS_PKG,
+} from '@nxrocks/common';
+
+export async function generateProjectConfiguration(
+  tree: Tree,
+  options: NormalizedSchema
+): Promise<void> {
+
+  logger.info(
+    `⚙️ Generating project configuration...`
+  );
+
+  const commands: BuilderCommandAliasType[] = [
+    'build',
+    'test',
+    'clean',
+  ];
+
+  if (!options.skipFormat) {
+    commands.push('format', 'apply-format', 'check-format');
+  }
+
+  const parentModuleCommands = [...commands];
+
+  const ktorOnlyCommands = [ 
+    'run',
+    'serve',
+    'build-image',
+    'publish-image',
+    'publish-image-locally',
+    'run-docker',
+  ];
+  commands.push(...ktorOnlyCommands);
+  
+
+  const getTargets = (commands: string[], rootFolder:string, runFromParentModule?:boolean) => {
+    const targets = {};
+    for (const command of commands) {
+      targets[command] = {
+        executor: `${NX_KTOR_PKG}:${command}`,
+        options: {
+          root: rootFolder,
+          ...(runFromParentModule? { runFromParentModule } : {}),
+        },
+        ...(command === 'build' ? { dependsOn: ['^install'] } : {}),
+        ...(['publish-image', 'publish-image-locally', 'run-docker'].includes(
+          command
+        )
+          ? { dependsOn: ['build-image'] }
+          : {}),
+        ...(['build', 'build-image', 'install', 'test'].includes(command)
+          ? {
+              outputs: [
+                `{workspaceRoot}/${rootFolder}/${
+                  options.buildSystem === 'MAVEN' ? 'target' : 'build'
+                }`,
+              ],
+            }
+          : {}),
+      };
+    }
+
+    return targets;
+  }
+
+  if(options.transformIntoMultiModule){
+
+    addProjectConfiguration(tree, options.parentModuleName, {
+      root: options.moduleRoot,
+      sourceRoot: `${options.moduleRoot}`,
+      projectType: 'application',
+      targets: getTargets(parentModuleCommands, options.moduleRoot, false),
+      tags: options.parsedTags,
+    });
+  }
+
+  addProjectConfiguration(tree, options.projectName, {
+    root: options.projectRoot,
+    sourceRoot: `${options.projectRoot}/src`,
+    projectType: 'application',
+    targets: getTargets(commands, options.projectRoot, !options.keepProjectLevelWrapper),
+    tags: options.parsedTags,
+  });
+}

--- a/packages/nx-ktor/src/generators/project/lib/index.ts
+++ b/packages/nx-ktor/src/generators/project/lib/index.ts
@@ -1,6 +1,8 @@
  export { generateKtorProject } from './generate-ktor-project';
+ export { generateProjectConfiguration} from './generate-project-configuration';
  export { addFormattingWithSpotless } from './add-formatting-with-spotless';
  export { addMavenPublishPlugin } from './add-maven-publish-plugin';
  export { normalizeOptions } from './normalize-options';
  export { promptKtorFeatures } from './prompt-ktor-features';
  export { addDockerfile } from './add-dockerfile';
+ export { promptForMultiModuleSupport } from './prompt-multi-module-support';

--- a/packages/nx-ktor/src/generators/project/lib/prompt-multi-module-support.ts
+++ b/packages/nx-ktor/src/generators/project/lib/prompt-multi-module-support.ts
@@ -1,0 +1,117 @@
+import { logger, createProjectGraphAsync, ProjectGraph, Tree, readCachedProjectGraph } from "@nx/devkit";
+import { prompt } from 'enquirer';
+
+import { NormalizedSchema } from "../schema";
+import { addGradleModule, addMavenModule, initGradleParentModule, initMavenParentModule, hasMultiModuleGradleProjectInTree, hasMultiModuleMavenProjectInTree } from "@nxrocks/common";
+
+export async function promptForMultiModuleSupport(tree: Tree, options: NormalizedSchema) {
+
+    const buildSystemName = options.buildSystem === 'MAVEN' ? 'Maven' : 'Gradle';
+
+    if (
+        (options.transformIntoMultiModule === undefined || options.addToExistingParentModule === undefined) &&
+        options.parentModuleName === undefined &&
+        process.env.NX_INTERACTIVE === 'true'
+    ) {
+        logger.info(`⏳ Checking for existing multi-module projects. Please wait...`);
+
+        const projectGraph: ProjectGraph = await createProjectGraphAsync();
+
+        const multiModuleProjects = Object.values(projectGraph.nodes).map(n => n.data).filter(project => options.buildSystem === 'MAVEN' ? hasMultiModuleMavenProjectInTree(tree, project.root) : hasMultiModuleGradleProjectInTree(tree, project.root))
+
+        if (multiModuleProjects.length === 0) {
+            options.transformIntoMultiModule = await prompt({
+                name: 'transformIntoMultiModule',
+                message:
+                    `Would you like to transform the generated project into a ${buildSystemName} multi-module project?`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['transformIntoMultiModule']);
+
+            if (options.transformIntoMultiModule) {
+                options.parentModuleName = (await prompt({
+                    name: 'parentModuleName',
+                    message:
+                        `What name would you like to use for the ${buildSystemName} multi-module project?`,
+                    type: 'input',
+                    initial: `${options.projectName}-parent`
+                }).then((a) => a['parentModuleName'])).replace(/\//g, '-');
+
+                options.keepProjectLevelWrapper = await prompt({
+                    name: 'keepProjectLevelWrapper',
+                    message:
+                        `A root ${buildSystemName} wrapper will be added in the root module '${options.parentModuleName}'. Do you want to keep the one in the generated child module '${options.projectName}'?`,
+                    type: 'confirm',
+                    initial: false
+                }).then((a) => a['keepProjectLevelWrapper']);
+            }
+        }
+        else {
+            options.addToExistingParentModule = await prompt({
+                name: 'addToExistingParentModule',
+                message:
+                `We found ${multiModuleProjects.length} existing ${buildSystemName} multi-module projects in your workaspace${multiModuleProjects.length === 1 ? `('${multiModuleProjects[0].name}')` : ''}.\nWould you like to add this new project ${multiModuleProjects.length === 1 ? 'to it?' : 'into one of them?'}`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['addToExistingParentModule']);
+
+            if (options.addToExistingParentModule) {
+                if (multiModuleProjects.length === 1) {
+                    options.parentModuleName = multiModuleProjects[0].name;
+                }
+                else {
+                    options.parentModuleName = await prompt({
+                        name: 'parentModuleName',
+                        message:
+                        'Which parent module would you like to add the new project into?',
+                        type: 'select',
+                        choices: multiModuleProjects.map(p => p.name),
+                    }).then((a) => a['parentModuleName']);
+                }
+            }
+
+        }
+    }
+    if((options.transformIntoMultiModule || options.addToExistingParentModule) && options.parentModuleName){
+        const helpComment = `For more information about ${buildSystemName} multi-modules projects, go to: ${options.buildSystem === 'MAVEN' ? 'https://maven.apache.org/guides/mini/guide-multiple-modules-4.html' : 'https://docs.gradle.org/current/userguide/intro_multi_project_builds.html'}`;
+
+        await adjustOptionsForMultiModules(options);
+
+        if(options.transformIntoMultiModule){
+            // add the root module
+            if(options.buildSystem === 'MAVEN'){
+                initMavenParentModule(tree, options.moduleRoot, options.groupId, options.parentModuleName, options.projectName, `<!-- ${helpComment} -->`);
+            }
+            else {
+                initGradleParentModule(tree, options.moduleRoot, options.parentModuleName, options.projectName, options. buildSystem === 'GRADLE_KTS', `// ${helpComment}`);
+            }
+        }
+        else if(options.addToExistingParentModule){
+            // add to the chosen root module
+            if(options.buildSystem === 'MAVEN'){
+                addMavenModule(tree, options.moduleRoot, options.projectName);
+            }
+            else {
+                addGradleModule(tree, options.moduleRoot, options.projectName, options. buildSystem === 'GRADLE_KTS');
+            }
+        }
+    }
+}
+
+async function adjustOptionsForMultiModules(options: NormalizedSchema) {
+
+    const projectGraph: ProjectGraph = process.env.NX_INTERACTIVE === 'true' ? readCachedProjectGraph() : await createProjectGraphAsync();
+
+    if(options.addToExistingParentModule && !projectGraph.nodes[options.parentModuleName]){
+        throw new Error(`No parent module project named '${options.parentModuleName}' was found in this workspace! Make sure the project exists.`);
+    }
+    const lastIndexOfPathSlash = options.projectRoot.lastIndexOf('/');
+    if(options.addToExistingParentModule){
+        options.moduleRoot = projectGraph.nodes[options.parentModuleName].data.root;
+    }
+    else {
+        const rootFolder = options.projectRoot.substring(0, lastIndexOfPathSlash);
+        options.moduleRoot = `${rootFolder}/${options.parentModuleName}`;
+    }
+    options.projectRoot = `${options.moduleRoot}/${options.projectRoot.substring(lastIndexOfPathSlash + 1)}`;
+}

--- a/packages/nx-ktor/src/generators/project/schema.d.ts
+++ b/packages/nx-ktor/src/generators/project/schema.d.ts
@@ -16,6 +16,11 @@ export interface ProjectGeneratorOptions {
   features?: string;
   skipFormat?: boolean;
   skipCodeSamples?: boolean;
+
+  transformIntoMultiModule?: boolean;
+  addToExistingParentModule?: boolean;
+  parentModuleName?: string;
+  keepProjectLevelWrapper?: boolean
 }
 
 export interface NormalizedSchema extends ProjectGeneratorOptions {
@@ -23,5 +28,6 @@ export interface NormalizedSchema extends ProjectGeneratorOptions {
   projectRoot: string;
   projectDirectory: string;
   projectFeatures: string[];
-  parsedTags: string[];
+  parsedTags: string[];  
+  moduleRoot?: string;
 }

--- a/packages/nx-ktor/src/generators/project/schema.json
+++ b/packages/nx-ktor/src/generators/project/schema.json
@@ -138,6 +138,23 @@
       "type": "string",
       "x-priority": "important"
     },
+    "transformIntoMultiModule": {
+      "description": "Transform the project into a multi-module project. Follow this guide https://t.ly/dZelN for more information.",
+      "type": "boolean"
+    },
+    "addToExistingParentModule": {
+      "description": "Add the project into an existing parent module project. Follow this guide https://t.ly/dZelN for more information.",
+      "type": "boolean"
+    },
+    "parentModuleName": {
+      "description": "Name of the parent module to create or to add child project into.",
+      "type": "string"
+    },
+    "keepProjectLevelWrapper": {
+      "description": "Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Follow this guide https://t.ly/dZelN for more information.",
+      "type": "boolean",
+      "default": true
+    },
     "ktorInitializrUrl": {
       "type": "string",
       "default": "https://ktor-plugin.europe-north1-gke.intellij.net",

--- a/packages/nx-ktor/src/utils/ktor-utils.ts
+++ b/packages/nx-ktor/src/utils/ktor-utils.ts
@@ -9,6 +9,8 @@ import {
   runBuilderCommand,
   getCommonHttpHeaders,
   NX_KTOR_PKG,
+  hasMultiModuleGradleProject,
+  hasMultiModuleMavenProject,
 } from '@nxrocks/common';
 
 import { MAVEN_BUILDER, GRADLE_BUILDER } from '../core/constants';
@@ -36,16 +38,15 @@ export function runKtorPluginCommand(
   commandAlias: BuilderCommandAliasType,
   params: string[],
   options: {
-    cwd?: string;
+    cwd: string;
     ignoreWrapper?: boolean;
     useLegacyWrapper?: boolean;
-  } = { ignoreWrapper: false, useLegacyWrapper: true }
+    runFromParentModule?: boolean;
+  } = { cwd: process.cwd(), ignoreWrapper: false, useLegacyWrapper: true, runFromParentModule: false }
 ): { success: boolean } {
   //force use legacy wrapper for all executors
   options = { ...options, useLegacyWrapper: true };
-  console.log(
-    `runKtorPluginCommand, ignoreWrapper: ${options.ignoreWrapper}, useLegacyWrapper: ${options.useLegacyWrapper}`
-  );
+
   return runBuilderCommand(commandAlias, getBuilder, params, options);
 }
 
@@ -71,6 +72,9 @@ export function buildKtorDownloadUrl(options: NormalizedSchema) {
 }
 
 export function isKtorProject(project: ProjectConfiguration): boolean {
+  if(hasMultiModuleMavenProject(project.root) || hasMultiModuleGradleProject(project.root))
+    return true;
+
   if (isMavenProject(project)) {
     return checkProjectBuildFileContains(project, {
       fragments: ['<version>${ktor_version}</version>'],

--- a/packages/nx-micronaut/README.md
+++ b/packages/nx-micronaut/README.md
@@ -22,9 +22,10 @@ Here is a list of some of the coolest features of the plugin:
 
 - ✅ Generation of Micronaut applications based on **Micronaut Launch** API
 - ✅ Building, packaging, testing, etc your Micronaut projects
-- ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
-- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
-- ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Micronaut's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
+- ✅ 🆕 Built-in support for creating [**multi-modules**](recipes/README.md#creating-mulit-modules-micronaut-projects) Micronaut projects with both `Maven` and `Gradle`
+- ✅ Built-in support for code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for `Maven` or `Gradle`
+- ✅ Built-in support for **corporate proxies** (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
+- ✅ Integration with Nx's **dependency graph** (through `nx graph` or `nx affected:graph`): this allows you to **visualize** the dependencies of any Micronaut's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
 - ...
 
 ## Prerequisite
@@ -79,21 +80,25 @@ Here the list of available generation options :
 | --------- | ------------------------- |
 | `<name>`  | The name of your project. |
 
-| Option               | Value                                                     | Description                                                                                             |
-| -------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `projectType`        | `default` \| `cli` \| `function` \| `grpc` \| `messaging` | Type of application to generate                                                                         |
-| `buildSystem`        | `MAVEN` \| `GRADLE` \| `GRADLE_KOTLIN`                    | Build system                                                                                            |
-| `basePackage`        | `string`                                                  | Base package of the project                                                                             |
-| `javaVersion`        | `JDK_8` \| `JDK_11` \| `JDK_17`                           | Java version to use                                                                                     |
-| `language`           | `JAVA` \| `GROOVY` \| `KOTLIN`                            | Language to use                                                                                         |
-| `testFramework`      | `JUNIT` \| `SPOCK` \| `KOTEST`                            | Test Framework to use                                                                                   |
-| `skipFormat`         | `boolean`                                                 | Do not add the ability to format code (using Spotless plugin)                                           |
-| `features`           | `string`                                                  | List of features to use (comma-separated). Go to https://micronaut.io/launch to get the ids needed here |
-| `micronautVersion`   | `current` \| `snapshot` \| `previous`                     | Micronaut version to use                                                                                |
-| `micronautLaunchUrl` | `https://launch.micronaut.io`                             | URL to the Micronaut Launch instance to use                                                             |
-| `proxyUrl`           |                                                           | The URL of the (corporate) proxy server to use to access Micronaut Launch                               |
-| `tags`               | `string`                                                  | Tags to use for linting (comma-separated)                                                               |
-| `directory`          | `string`                                                  | Directory where the project is placed                                                                   |
+| Option                     | Value                                                     | Description                                                                                             |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `projectType`              | `default` \| `cli` \| `function` \| `grpc` \| `messaging` | Type of application to generate                                                                         |
+| `buildSystem`              | `MAVEN` \| `GRADLE` \| `GRADLE_KOTLIN`                    | Build system                                                                                            |
+| `basePackage`              | `string`                                                  | Base package of the project                                                                             |
+| `javaVersion`              | `JDK_8` \| `JDK_11` \| `JDK_17`                           | Java version to use                                                                                     |
+| `language`                 | `JAVA` \| `GROOVY` \| `KOTLIN`                            | Language to use                                                                                         |
+| `testFramework`            | `JUNIT` \| `SPOCK` \| `KOTEST`                            | Test Framework to use                                                                                   |
+| `skipFormat`               | `boolean`                                                 | Do not add the ability to format code (using Spotless plugin)                                           |
+| `features`                 | `string`                                                  | List of features to use (comma-separated). Go to https://micronaut.io/launch to get the ids needed here |
+| `transformIntoMultiModule` | `boolean`                                                 | Transform the project into a multi-module project. Go to [recipes](recipes/README.md#creating-mulit-modules-micronaut-projects) for more information               |
+| `addToExistingParentModule`| `boolean`                                                 | Add the project into an existing parent module project. Go to [recipes](recipes/README.md#creating-mulit-modules-micronaut-projects) for more information               |
+| `parentModuleName`         | `string`                                                  | Name of the parent module to create or to add child project into. Go to [recipes](recipes/README.md#creating-mulit-modules-micronaut-projects) for more information               |
+| `keepProjectLevelWrapper`  | `boolean`                                                 | Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Go to [recipes](recipes/README.md#creating-mulit-modules-micronaut-projects) for more information               |
+| `micronautVersion`         | `current` \| `snapshot` \| `previous`                     | Micronaut version to use                                                                                |
+| `micronautLaunchUrl`       | `https://launch.micronaut.io`                             | URL to the Micronaut Launch instance to use                                                             |
+| `proxyUrl`                 |                                                           | The URL of the (corporate) proxy server to use to access Micronaut Launch                               |
+| `tags`                     | `string`                                                  | Tags to use for linting (comma-separated)                                                               |
+| `directory`                | `string`                                                  | Directory where the project is placed                                                                   |
 
 > **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
 > Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Micronaut Launch to generate the project.
@@ -140,16 +145,16 @@ Once your app is generated, you can now use buidlers to manage it.
 
 Here the list of available executors:
 
-| Executor                  | Arguments                                 | Description                                                                                                                                                                |
-| ------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run` \| `dev` \| `serve` | `ignoreWrapper:boolean`, `args: string[]` | Runs the project in dev mode using either `./mvnw\|mvn micronaut:dev` or `./gradlew\|gradle micronautDev`                                                                  |
-| `dockerfile`              | `ignoreWrapper:boolean`, `args: string[]` | Generates a `Dockerfile` depending on the `packaging` and `micronaut.runtime properties` using either `./mvnw\|mvn micronaut:dockerfile` or `./gradlew\|gradle dockerfile` |
-| `build`                   | `ignoreWrapper:boolean`, `args: string[]` | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle build`                                                                                       |
-| `install`                 | `ignoreWrapper:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal`           |
-| `test`                    | `ignoreWrapper:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                              |
-| `clean`                   | `ignoreWrapper:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                           |
-| `format`                  | `ignoreWrapper:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                                       |
-| `aotConfigSample`         | `ignoreWrapper:boolean`, `args: string[]` | Generates a sample `aot.properties` using either `./mvnw\|mvn package` or `./gradlew\|gradle package`                                                                      |
+| Executor                  | Arguments                                                                | Description                                                                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run` \| `dev` \| `serve` | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Runs the project in dev mode using either `./mvnw\|mvn micronaut:dev` or `./gradlew\|gradle micronautDev`                                                                  |
+| `dockerfile`              | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Generates a `Dockerfile` depending on the `packaging` and `micronaut.runtime properties` using either `./mvnw\|mvn micronaut:dockerfile` or `./gradlew\|gradle dockerfile` |
+| `build`                   | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle build`                                                                                       |
+| `install`                 | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal`           |
+| `test`                    | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                              |
+| `clean`                   | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                           |
+| `format`                  | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                                       |
+| `aotConfigSample`         | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Generates a sample `aot.properties` using either `./mvnw\|mvn package` or `./gradlew\|gradle package`                                                                      |
 
 In order to execute the requested command, each executor will use, by default, the embedded `./mvnw` or `./gradlew` executable, that was generated alongside the project.
 If you want to rely on a globally installed `mvn` or `gradle` executable instead, add the `--ignoreWrapper` option to bypass it.
@@ -207,7 +212,7 @@ nx build your-micronaut-app
 ### Install the project's artifacts to local Maven repository (in `~/.m2/repository`) - (`install` Executor)
 
 ```
-nx install your-quarkus-app
+nx install your-micronaut-app
 ```
 
 ### Generating the project dockerfile - (`dockerfile` Executor)

--- a/packages/nx-micronaut/recipes/README.md
+++ b/packages/nx-micronaut/recipes/README.md
@@ -18,3 +18,15 @@ You will need to fetch and enter the features ids manually:
 
 3. In Nx Console UI, enter the features ids you want to use, separated by a comma
 ![Adding features in Nx Console](images/nx-console-add-features.png)
+
+## Creating mulit-modules Micronaut projects
+
+The support for creating multi-module Micronaut project with either `Maven` or `Gradle` was added to the plugin since `v6.1.0`.
+
+When generating a new project, you can now choose either to:
+
+* Transform the project being generated into a multi-module project by setting `transformIntoMultiModule` to `true` and by providing the name of the parent module to create on top of the child project, via `parentModuleName` option.
+* Add the project being generated into an existing multi-module project by setting `addToExistingParentModule` to `true` and by providing the name of the parent module to add the child project too.
+
+> **Note** When running the `@nxrocks/nx-micronaut:project` generator in **interactive mode** (i.e via command line),
+> we can automatically analyze your workspace and prompt for the appropriate above options to add multi-module support.

--- a/packages/nx-micronaut/src/executors/aot-sample-config/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Aot Sample Config Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' createAotSampleConfigurationFiles '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await aotSampleConfigExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/aot-sample-config/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { aotSampleConfigExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Aot Sample Config Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await aotSampleConfigExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/aot-sample-config/executor.ts
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/executor.ts
@@ -11,6 +11,7 @@ export async function aotSampleConfigExecutor(
   return runMicronautPluginCommand('aot-sample-config', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/aot-sample-config/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/schema.d.ts
@@ -2,5 +2,6 @@
 export interface AotSampleConfigExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/aot-sample-config/schema.json
+++ b/packages/nx-micronaut/src/executors/aot-sample-config/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/build/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/build/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Build Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' build '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/build/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/build/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { buildExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Build Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/build/executor.ts
+++ b/packages/nx-micronaut/src/executors/build/executor.ts
@@ -11,6 +11,7 @@ export async function buildExecutor(
   return runMicronautPluginCommand('build', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/build/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/build/schema.d.ts
@@ -2,5 +2,6 @@
 export interface BuildExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/build/schema.json
+++ b/packages/nx-micronaut/src/executors/build/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/check-format/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Format Check Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' spotlessCheck '}
   `(
     'should execute a $buildSystem format check and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/check-format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatCheckExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Format Check Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/check-format/executor.ts
+++ b/packages/nx-micronaut/src/executors/check-format/executor.ts
@@ -11,6 +11,7 @@ export async function formatCheckExecutor(
   return runMicronautPluginCommand('check-format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/check-format/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/check-format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatCheckExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/check-format/schema.json
+++ b/packages/nx-micronaut/src/executors/check-format/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/clean/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/clean/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Clean Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' clean '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/clean/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/clean/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { cleanExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Clean Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/clean/executor.ts
+++ b/packages/nx-micronaut/src/executors/clean/executor.ts
@@ -11,6 +11,7 @@ export async function cleanExecutor(
   return runMicronautPluginCommand('clean', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/clean/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/clean/schema.d.ts
@@ -2,5 +2,6 @@
 export interface CleanExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/clean/schema.json
+++ b/packages/nx-micronaut/src/executors/clean/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Maven or Gradle command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/dockerfile/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/dockerfile/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { buildExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('DockerfileJar Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/dockerfile/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/dockerfile/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('DockerfileJar Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' dockerfile '}
   `(
     'should execute a $buildSystem dockerfile and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/dockerfile/executor.ts
+++ b/packages/nx-micronaut/src/executors/dockerfile/executor.ts
@@ -11,6 +11,7 @@ export async function buildExecutor(
   return runMicronautPluginCommand('dockerfile', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/dockerfile/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/dockerfile/schema.d.ts
@@ -2,5 +2,6 @@
 export interface DockerfileExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/dockerfile/schema.json
+++ b/packages/nx-micronaut/src/executors/dockerfile/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/format/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/format/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('FormatJar Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' spotlessApply '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/format/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('FormatJar Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/format/executor.ts
+++ b/packages/nx-micronaut/src/executors/format/executor.ts
@@ -11,6 +11,7 @@ export async function formatExecutor(
   return runMicronautPluginCommand('format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/format/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/format/schema.json
+++ b/packages/nx-micronaut/src/executors/format/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/install/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/install/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { installExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Install Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/install/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/install/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Install Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishToMavenLocal '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/install/executor.ts
+++ b/packages/nx-micronaut/src/executors/install/executor.ts
@@ -11,6 +11,7 @@ export async function installExecutor(
   return runMicronautPluginCommand('install', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/install/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/install/schema.d.ts
@@ -2,5 +2,6 @@
 export interface InstallExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/install/schema.json
+++ b/packages/nx-micronaut/src/executors/install/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/run/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/run/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { runExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Run Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await runExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/run/executor.ts
+++ b/packages/nx-micronaut/src/executors/run/executor.ts
@@ -11,6 +11,7 @@ export async function runExecutor(
   return runMicronautPluginCommand('run', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/run/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/run/schema.d.ts
@@ -2,5 +2,6 @@
 export interface RunExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/run/schema.json
+++ b/packages/nx-micronaut/src/executors/run/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/executors/test/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/test/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE_LEGACY,
   NX_MICRONAUT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Test Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' test '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/test/executor.spec.ts
+++ b/packages/nx-micronaut/src/executors/test/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { testExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Test Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-micronaut/src/executors/test/executor.ts
+++ b/packages/nx-micronaut/src/executors/test/executor.ts
@@ -11,6 +11,7 @@ export async function testExecutor(
   return runMicronautPluginCommand('test', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-micronaut/src/executors/test/schema.d.ts
+++ b/packages/nx-micronaut/src/executors/test/schema.d.ts
@@ -2,5 +2,6 @@
 export interface TestExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-micronaut/src/executors/test/schema.json
+++ b/packages/nx-micronaut/src/executors/test/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Micronaut command",
       "type": "array",

--- a/packages/nx-micronaut/src/generators/project/generator.spec.ts
+++ b/packages/nx-micronaut/src/generators/project/generator.spec.ts
@@ -258,12 +258,12 @@ describe('project generator', () => {
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        1,
+        2,
         `⬇️ Downloading Micronaut project zip from : '${downloadUrl}'...`
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        2,
+        3,
         `📦 Extracting Micronaut project zip to '${workspaceRoot}/${rootDir}/${options.name}'...`
       );
     }

--- a/packages/nx-micronaut/src/generators/project/lib/generate-micronaut-project.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/generate-micronaut-project.ts
@@ -6,6 +6,8 @@ import { buildMicronautDownloadUrl } from '../../../utils/micronaut-utils';
 import {
   extractFromZipStream,
   getCommonHttpHeaders,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
   NX_MICRONAUT_PKG,
 } from '@nxrocks/common';
 
@@ -38,9 +40,24 @@ export async function generateMicronautProject(
         filePath.endsWith('mvnw') || filePath.endsWith('gradlew')
           ? '755'
           : undefined;
-      tree.write(`${options.projectRoot}/${filePath}`, entryContent, {
-        mode: execPermission,
-      });
+      if (getMavenWrapperFiles().includes(filePath) || getGradleWrapperFiles().includes(filePath)) {
+        if (options.transformIntoMultiModule) {
+          tree.write(`${options.moduleRoot}/${filePath}`, entryContent, {
+            mode: execPermission,
+          });
+        }
+        if (options.keepProjectLevelWrapper) {
+          tree.write(`${options.projectRoot}/${filePath}`, entryContent, {
+            mode: execPermission,
+          });
+        }
+
+      }
+      else {
+        tree.write(`${options.projectRoot}/${filePath}`, entryContent, {
+          mode: execPermission,
+        });
+      }
     });
   } else {
     throw new Error(stripIndents`

--- a/packages/nx-micronaut/src/generators/project/lib/generate-project-configuration.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/generate-project-configuration.ts
@@ -1,0 +1,81 @@
+import { Tree, addProjectConfiguration, logger } from '@nx/devkit';
+import { NormalizedSchema } from '../schema';
+import {
+  BuilderCommandAliasType,
+  NX_MICRONAUT_PKG,
+  NX_QUARKUS_PKG,
+} from '@nxrocks/common';
+
+export async function generateProjectConfiguration(
+  tree: Tree,
+  options: NormalizedSchema
+): Promise<void> {
+
+  logger.info(
+    `⚙️ Generating project configuration...`
+  );
+
+  const commands: BuilderCommandAliasType[] = [
+    'build',
+    'test',
+    'clean',
+  ];
+
+  if (!options.skipFormat) {
+    commands.push('format', 'apply-format', 'check-format');
+  }
+
+  const parentModuleCommands = [...commands];
+
+  const mnOnlyCommands = [ 
+    'run',
+    'serve',
+    'dockerfile',
+    'aot-sample-config',
+  ];
+  commands.push(...mnOnlyCommands);
+  
+
+  const getTargets = (commands: string[], rootFolder:string, runFromParentModule?:boolean) => {
+    const targets = {};
+    for (const command of commands) {
+      targets[command] = {
+        executor: `${NX_MICRONAUT_PKG}:${command}`,
+        options: {
+          root: rootFolder,
+          ...(runFromParentModule? { runFromParentModule } : {}),
+        },
+        ...(command === 'build' ? { dependsOn: ['^install'] } : {}),
+        ...(['build', 'install', 'test'].includes(command)
+          ? {
+              outputs: [
+                `{workspaceRoot}/${rootFolder}/${
+                  options.buildSystem === 'MAVEN' ? 'target' : 'build'
+                }`,
+              ],
+            }
+          : {}),
+      };
+    }
+    return targets;
+  }
+
+  if(options.transformIntoMultiModule){
+
+    addProjectConfiguration(tree, options.parentModuleName, {
+      root: options.moduleRoot,
+      sourceRoot: `${options.moduleRoot}`,
+      projectType: 'application',
+      targets: getTargets(parentModuleCommands, options.moduleRoot, false),
+      tags: options.parsedTags,
+    });
+  }
+
+  addProjectConfiguration(tree, options.projectName, {
+    root: options.projectRoot,
+    sourceRoot: `${options.projectRoot}/src`,
+    projectType: 'application',
+    targets: getTargets(commands, options.projectRoot, !options.keepProjectLevelWrapper),
+    tags: options.parsedTags,
+  });
+}

--- a/packages/nx-micronaut/src/generators/project/lib/index.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/index.ts
@@ -1,5 +1,7 @@
  export { generateMicronautProject } from './generate-micronaut-project';
+ export { generateProjectConfiguration} from './generate-project-configuration';
  export { addFormattingWithSpotless } from './add-formatting-with-spotless';
  export { addMavenPublishPlugin } from './add-maven-publish-plugin';
  export { normalizeOptions } from './normalize-options';
- export { promptMicronautFeatures } from './prompt-micronaut-features'
+ export { promptMicronautFeatures } from './prompt-micronaut-features';
+ export { promptForMultiModuleSupport } from './prompt-multi-module-support';

--- a/packages/nx-micronaut/src/generators/project/lib/prompt-multi-module-support.ts
+++ b/packages/nx-micronaut/src/generators/project/lib/prompt-multi-module-support.ts
@@ -1,0 +1,117 @@
+import { logger, createProjectGraphAsync, ProjectGraph, Tree, readCachedProjectGraph } from "@nx/devkit";
+import { prompt } from 'enquirer';
+
+import { NormalizedSchema } from "../schema";
+import { addGradleModule, addMavenModule, initGradleParentModule, initMavenParentModule, hasMultiModuleGradleProjectInTree, hasMultiModuleMavenProjectInTree } from "@nxrocks/common";
+
+export async function promptForMultiModuleSupport(tree: Tree, options: NormalizedSchema) {
+
+    const buildSystemName = options.buildSystem === 'MAVEN' ? 'Maven' : 'Gradle';
+    if (
+        (options.transformIntoMultiModule === undefined || options.addToExistingParentModule === undefined) &&
+        options.parentModuleName === undefined &&
+        process.env.NX_INTERACTIVE === 'true'
+    ) {
+        logger.info(`⏳ Checking for existing multi-module projects. Please wait...`);
+
+        const projectGraph: ProjectGraph = await createProjectGraphAsync();
+
+        const multiModuleProjects = Object.values(projectGraph.nodes).map(n => n.data).filter(project => options.buildSystem === 'MAVEN' ? hasMultiModuleMavenProjectInTree(tree, project.root) : hasMultiModuleGradleProjectInTree(tree, project.root))
+
+        if (multiModuleProjects.length === 0) {
+            options.transformIntoMultiModule = await prompt({
+                name: 'transformIntoMultiModule',
+                message:
+                    `Would you like to transform the generated project into a ${buildSystemName} multi-module project?`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['transformIntoMultiModule']);
+
+            if (options.transformIntoMultiModule) {
+                options.parentModuleName = (await prompt({
+                    name: 'parentModuleName',
+                    message:
+                        `What name would you like to use for the ${buildSystemName} multi-module project?`,
+                    type: 'input',
+                    initial: `${options.projectName}-parent`
+                }).then((a) => a['parentModuleName'])).replace(/\//g, '-');
+
+                options.keepProjectLevelWrapper = await prompt({
+                    name: 'keepProjectLevelWrapper',
+                    message:
+                        `A root ${buildSystemName} wrapper will be added in the root module '${options.parentModuleName}'. Do you want to keep the one in the generated child module '${options.projectName}'?`,
+                    type: 'confirm',
+                    initial: false
+                }).then((a) => a['keepProjectLevelWrapper']);
+            }
+        }
+        else {
+            options.addToExistingParentModule = await prompt({
+                name: 'addToExistingParentModule',
+                message:
+                `We found ${multiModuleProjects.length} existing ${buildSystemName} multi-module projects in your workaspace${multiModuleProjects.length === 1 ? `('${multiModuleProjects[0].name}')` : ''}.\nWould you like to add this new project ${multiModuleProjects.length === 1 ? 'to it?' : 'into one of them?'}`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['addToExistingParentModule']);
+
+            if (options.addToExistingParentModule) {
+                if (multiModuleProjects.length === 1) {
+                    options.parentModuleName = multiModuleProjects[0].name;
+                }
+                else {
+                    options.parentModuleName = await prompt({
+                        name: 'parentModuleName',
+                        message:
+                        'Which parent module would you like to add the new project into?',
+                        type: 'select',
+                        choices: multiModuleProjects.map(p => p.name),
+                    }).then((a) => a['parentModuleName']);
+                }
+            }
+
+        }
+    }
+
+    if((options.transformIntoMultiModule || options.addToExistingParentModule) && options.parentModuleName){
+        const helpComment = `For more information about ${buildSystemName} multi-modules projects, go to: ${options.buildSystem === 'MAVEN' ? 'https://maven.apache.org/guides/mini/guide-multiple-modules-4.html' : 'https://docs.gradle.org/current/userguide/intro_multi_project_builds.html'}`;
+
+        await adjustOptionsForMultiModules(options);
+
+        if(options.transformIntoMultiModule){
+            // add the root module
+            if(options.buildSystem === 'MAVEN'){
+                initMavenParentModule(tree, options.moduleRoot, options.basePackage, options.parentModuleName, options.projectName, `<!-- ${helpComment} -->`);
+            }
+            else {
+                initGradleParentModule(tree, options.moduleRoot, options.parentModuleName, options.projectName, options. buildSystem === 'GRADLE_KOTLIN', `// ${helpComment}`);
+            }
+        }
+        else if(options.addToExistingParentModule){
+            // add to the chosen root module
+            if(options.buildSystem === 'MAVEN'){
+                addMavenModule(tree, options.moduleRoot, options.projectName);
+            }
+            else {
+                addGradleModule(tree, options.moduleRoot, options.projectName, options. buildSystem === 'GRADLE_KOTLIN');
+            }
+        }
+    }
+}
+
+async function adjustOptionsForMultiModules(options: NormalizedSchema) {
+
+    const projectGraph: ProjectGraph = process.env.NX_INTERACTIVE === 'true' ? readCachedProjectGraph() : await createProjectGraphAsync();
+
+    if(options.addToExistingParentModule && !projectGraph.nodes[options.parentModuleName]){
+        throw new Error(`No parent module project named '${options.parentModuleName}' was found in this workspace! Make sure the project exists.`);
+    }
+    const lastIndexOfPathSlash = options.projectRoot.lastIndexOf('/');
+    if(options.addToExistingParentModule){
+        options.moduleRoot = projectGraph.nodes[options.parentModuleName].data.root;
+    }
+    else {
+        const rootFolder = options.projectRoot.substring(0, lastIndexOfPathSlash);
+        options.moduleRoot = `${rootFolder}/${options.parentModuleName}`;
+    }
+    options.projectRoot = `${options.moduleRoot}/${options.projectRoot.substring(lastIndexOfPathSlash + 1)}`;
+}

--- a/packages/nx-micronaut/src/generators/project/schema.d.ts
+++ b/packages/nx-micronaut/src/generators/project/schema.d.ts
@@ -15,6 +15,11 @@ export interface ProjectGeneratorOptions {
   testFramework?: 'JUNIT' | 'SPOCK' | 'KOTEST';
   features?: string;
   skipFormat?: boolean;
+
+  transformIntoMultiModule?: boolean;
+  addToExistingParentModule?: boolean;
+  parentModuleName?: string;
+  keepProjectLevelWrapper?: boolean
 }
 
 export interface NormalizedSchema extends ProjectGeneratorOptions {
@@ -24,4 +29,5 @@ export interface NormalizedSchema extends ProjectGeneratorOptions {
   projectFeatures: string[];
   parsedTags: string[];
   fullPackage: string;
+  moduleRoot?: string;
 }

--- a/packages/nx-micronaut/src/generators/project/schema.json
+++ b/packages/nx-micronaut/src/generators/project/schema.json
@@ -210,6 +210,23 @@
       "type": "string",
       "x-priority": "important"
     },
+    "transformIntoMultiModule": {
+      "description": "Transform the project into a multi-module project. Follow this guide https://t.ly/ov0Y9 for more information.",
+      "type": "boolean"
+    },
+    "addToExistingParentModule": {
+      "description": "Add the project into an existing parent module project. Follow this guide https://t.ly/ov0Y9 for more information.",
+      "type": "boolean"
+    },
+    "parentModuleName": {
+      "description": "Name of the parent module to create or to add child project into.",
+      "type": "string"
+    },
+    "keepProjectLevelWrapper": {
+      "description": "Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Follow this guide https://t.ly/ov0Y9 for more information.",
+      "type": "boolean",
+      "default": true
+    },
     "micronautLaunchUrl": {
       "type": "string",
       "default": "https://launch.micronaut.io",

--- a/packages/nx-micronaut/src/utils/micronaut-utils.ts
+++ b/packages/nx-micronaut/src/utils/micronaut-utils.ts
@@ -9,6 +9,8 @@ import {
   runBuilderCommand,
   NX_MICRONAUT_PKG,
   getCommonHttpHeaders,
+  hasMultiModuleGradleProject,
+  hasMultiModuleMavenProject,
 } from '@nxrocks/common';
 
 import { MAVEN_BUILDER, GRADLE_BUILDER } from '../core/constants';
@@ -39,16 +41,14 @@ export function runMicronautPluginCommand(
   commandAlias: BuilderCommandAliasType,
   params: string[],
   options: {
-    cwd?: string;
+    cwd: string;
     ignoreWrapper?: boolean;
     useLegacyWrapper?: boolean;
-  } = { ignoreWrapper: false, useLegacyWrapper: true }
+    runFromParentModule?: boolean 
+  } = { cwd: process.cwd(), ignoreWrapper: false, useLegacyWrapper: true, runFromParentModule: false }
 ): { success: boolean } {
   //force use legacy wrapper for all executors
   options = { ...options, useLegacyWrapper: true };
-  console.log(
-    `runMicronautPluginCommand, ignoreWrapper: ${options.ignoreWrapper}, useLegacyWrapper: ${options.useLegacyWrapper}`
-  );
   return runBuilderCommand(commandAlias, getBuilder, params, options);
 }
 
@@ -85,6 +85,9 @@ export function buildMicronautDownloadUrl(options: NormalizedSchema) {
 }
 
 export function isMicronautProject(project: ProjectConfiguration): boolean {
+  if(hasMultiModuleMavenProject(project.root) || hasMultiModuleGradleProject(project.root))
+    return true;
+
   if (isMavenProject(project)) {
     return checkProjectBuildFileContains(project, {
       fragments: ['<artifactId>micronaut-parent</artifactId>'],

--- a/packages/nx-quarkus/README.md
+++ b/packages/nx-quarkus/README.md
@@ -22,12 +22,12 @@ Here is a list of some of the coolest features of the plugin:
 
 - ✅ Generation of Quarkus applications/libraries based on **Quarkus app generator** API
 - ✅ Building, packaging, testing, etc your Quarkus projects
-- ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
-- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
-- ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Quarkus's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
-
-  ![Nx Quarkus dependency graph](https://raw.githubusercontent.com/tinesoft/nxrocks/develop/images/nx-quarkus-dep-graph.png)
-  _Example of running the `nx dep-graph` command on a workspace with 2 Quarkus projects inside_
+- ✅ 🆕 Built-in support for creating [**multi-modules**](recipes/README.md#creating-mulit-modules-quarkus-projects) Quarkus projects with both `Maven` and `Gradle`
+- ✅ Built-in support for code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for `Maven` or `Gradle`
+- ✅ Built-in support for **corporate proxies** (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
+- ✅ Integration with Nx's **dependency graph** (through `nx graph` or `nx affected:graph`): this allows you to **visualize** the dependencies of any Quarkus's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
+  ![Nx Quarkus dependency graph](https://raw.githubusercontent.com/tinesoft/nxrocks/develop/images/nx-quarkus-graph.png)
+  _Example of running the `nx graph` command on a workspace with 2 Quarkus projects inside_
 
 - ...
 
@@ -83,19 +83,23 @@ Here the list of available generation options :
 | --------- | ------------------------- |
 | `<name>`  | The name of your project. |
 
-| Option                  | Value                      | Description                                                                                                          |
-| ----------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `projectType`           | `application` \| `library` | Type of project to generate                                                                                          |
-| `buildSystem`           | `MAVEN` \| `GRADLE`        | Build system                                                                                                         |
-| `groupId`               | `string`                   | GroupId of the project                                                                                               |
-| `artifactId`            | `string`                   | ArtifactId of the project                                                                                            |
-| `skipFormat`            | `boolean`                  | Do not add the ability to format code (using Spotless plugin)                                                        |
-| `extensions`            | `string`                   | List of extensions to use (comma-separated). Go to https://code.quarkus.io/api/extensions to get the ids needed here |
-| `quarkusInitializerUrl` | `https://code.quarkus.io`  | URL to the Quarkus Initializer instance to use                                                                       |
-| `proxyUrl`              |                            | The URL of the (corporate) proxy server to use to access Quarkus Initializer                                         |
-| `skipeCodeSamples`      | `string`                   | Whether or not to include code samples from extensions (when available)                                              |
-| `tags`                  | `string`                   | Tags to use for linting (comma-separated)                                                                            |
-| `directory`             | `string`                   | Directory where the project is placed                                                                                |
+| Option                     | Value                      | Description                                                                                                          |
+| -------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `projectType`              | `application` \| `library` | Type of project to generate                                                                                          |
+| `buildSystem`              | `MAVEN` \| `GRADLE`        | Build system                                                                                                         |
+| `groupId`                  | `string`                   | GroupId of the project                                                                                               |
+| `artifactId`               | `string`                   | ArtifactId of the project                                                                                            |
+| `skipFormat`               | `boolean`                  | Do not add the ability to format code (using Spotless plugin)                                                        |
+| `extensions`               | `string`                   | List of extensions to use (comma-separated). Go to [recipes](recipes/README.md#adding-quarkus-dependencies) for more information |
+| `transformIntoMultiModule` | `boolean`                  | Transform the project into a multi-module project. Go to [recipes](recipes/README.md#creating-mulit-modules-quarkus-projects) for more information               |
+| `addToExistingParentModule`| `boolean`                  | Add the project into an existing parent module project. Go to [recipes](recipes/README.md#creating-mulit-modules-quarkus-projects) for more information               |
+| `parentModuleName`         | `string`                   | Name of the parent module to create or to add child project into. Go to [recipes](recipes/README.md#creating-mulit-modules-quarkus-projects) for more information               |
+| `keepProjectLevelWrapper`  | `boolean`                  | Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Go to [recipes](recipes/README.md#creating-mulit-modules-quarkus-projects) for more information               |
+| `quarkusInitializerUrl`    | `https://code.quarkus.io`  | URL to the Quarkus Initializer instance to use                                                                       |
+| `proxyUrl`                 |                            | The URL of the (corporate) proxy server to use to access Quarkus Initializer                                         |
+| `skipeCodeSamples`         | `string`                   | Whether or not to include code samples from extensions (when available)                                              |
+| `tags`                     | `string`                   | Tags to use for linting (comma-separated)                                                                            |
+| `directory`                | `string`                   | Directory where the project is placed                                                                                |
 
 > **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
 > Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Quarkus Initializer to generate the project.
@@ -142,18 +146,18 @@ Once your app is generated, you can now use buidlers to manage it.
 
 Here the list of available executors:
 
-| Executor                  | Arguments                                 | Description                                                                                                                                                      |
-| ------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run` \| `dev` \| `serve` | `ignoreWrapper:boolean`, `args: string[]` | Runs the project in dev mode using either `./mvnw\|mvn quarkus:dev` or `./gradlew\|gradle quarkusDev`                                                            |
-| `remote-dev`              | `ignoreWrapper:boolean`, `args: string[]` | Runs the project in remote dev mode using either `./mvnw\|mvn quarkus:remote-dev` or `./gradlew\|gradle quarkusRemoteDev`                                        |
-| `build`                   | `ignoreWrapper:boolean`, `args: string[]` | Builds a native or container friendly image either `./mvnw\|mvn build` or `./gradlew\|gradle build`                                                              |
-| `test`                    | `ignoreWrapper:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                    |
-| `clean`                   | `ignoreWrapper:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                 |
-| `format`                  | `ignoreWrapper:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                             |
-| `package`                 | `ignoreWrapper:boolean`, `args: string[]` | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle package`                                                                           |
-| `install`                 | `ignoreWrapper:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
-| `add-extension`           | `ignoreWrapper:boolean`, `args: string[]` | Adds a new extension to the project using either `./mvnw\|mvn quarkus:add-extension` or `./gradlew\|gradle quarkusAddExtension`                                  |
-| `list-extensions`         | `ignoreWrapper:boolean`, `args: string[]` | Adds a new extension to the project using either `./mvnw\|mvn quarkus:list-extensions` or `./gradlew\|gradle quarkusListExtensions`                              |
+| Executor                  | Arguments                                                                | Description                                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run` \| `dev` \| `serve` | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Runs the project in dev mode using either `./mvnw\|mvn quarkus:dev` or `./gradlew\|gradle quarkusDev`                                                            |
+| `remote-dev`              | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Runs the project in remote dev mode using either `./mvnw\|mvn quarkus:remote-dev` or `./gradlew\|gradle quarkusRemoteDev`                                        |
+| `build`                   | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Builds a native or container friendly image either `./mvnw\|mvn build` or `./gradlew\|gradle build`                                                              |
+| `test`                    | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                    |
+| `clean`                   | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                 |
+| `format`                  | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                             |
+| `package`                 | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Packages the project using either `./mvnw\|mvn package` or `./gradlew\|gradle package`                                                                           |
+| `install`                 | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
+| `add-extension`           | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Adds a new extension to the project using either `./mvnw\|mvn quarkus:add-extension` or `./gradlew\|gradle quarkusAddExtension`                                  |
+| `list-extensions`         | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Adds a new extension to the project using either `./mvnw\|mvn quarkus:list-extensions` or `./gradlew\|gradle quarkusListExtensions`                              |
 
 In order to execute the requested command, each executor will use, by default, the embedded `./mvnw` or `./gradlew` executable, that was generated alongside the project.
 If you want to rely on a globally installed `mvn` or `gradle` executable instead, add the `--ignoreWrapper` option to bypass it.

--- a/packages/nx-quarkus/recipes/README.md
+++ b/packages/nx-quarkus/recipes/README.md
@@ -17,3 +17,15 @@ You will need to fetch and enter the extensions ids manually:
 
 2. In Nx Console UI, enter the extensions ids you want to use, separated by a comma
 ![Adding extensions in Nx Console](images/nx-console-add-extensions.png)
+
+## Creating mulit-modules Quarkus projects
+
+The support for creating multi-module Quarkus project with either `Maven` or `Gradle` was added to the plugin since `v6.1.0`.
+
+When generating a new project, you can now choose either to:
+
+* Transform the project being generated into a multi-module project by setting `transformIntoMultiModule` to `true` and by providing the name of the parent module to create on top of the child project, via `parentModuleName` option.
+* Add the project being generated into an existing multi-module project by setting `addToExistingParentModule` to `true` and by providing the name of the parent module to add the child project too.
+
+> **Note** When running the `@nxrocks/nx-quarkus:project` generator in **interactive mode** (i.e via command line),
+> we can automatically analyze your workspace and prompt for the appropriate above options to add multi-module support.

--- a/packages/nx-quarkus/src/executors/add-extension/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/add-extension/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Add Extension Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' quarkusAddExtension '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await addExtensionExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/add-extension/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/add-extension/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { addExtensionExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Add Extension Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await addExtensionExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/add-extension/executor.ts
+++ b/packages/nx-quarkus/src/executors/add-extension/executor.ts
@@ -11,6 +11,7 @@ export async function addExtensionExecutor(
   return runQuarkusPluginCommand('add-extension', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/add-extension/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/add-extension/schema.d.ts
@@ -2,6 +2,7 @@
 export interface AddExtensionExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     extensions?: string;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/add-extension/schema.json
+++ b/packages/nx-quarkus/src/executors/add-extension/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/build/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/build/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { buildExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Build Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/build/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/build/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Build Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' build '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
-      (fsUtility.fileExists as jest.Mock).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
+      mocked(fsUtility.fileExists).mockImplementation(
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/build/executor.ts
+++ b/packages/nx-quarkus/src/executors/build/executor.ts
@@ -11,6 +11,7 @@ export async function buildExecutor(
   return runQuarkusPluginCommand('build', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/build/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/build/schema.d.ts
@@ -2,5 +2,6 @@
 export interface BuildExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/build/schema.json
+++ b/packages/nx-quarkus/src/executors/build/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/check-format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatCheckExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Format Check Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/check-format/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Format Check Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' spotlessCheck '}
   `(
     'should execute a $buildSystem format check and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/check-format/executor.ts
+++ b/packages/nx-quarkus/src/executors/check-format/executor.ts
@@ -11,6 +11,7 @@ export async function formatCheckExecutor(
   return runQuarkusPluginCommand('check-format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/check-format/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/check-format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatCheckExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/check-format/schema.json
+++ b/packages/nx-quarkus/src/executors/check-format/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/clean/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/clean/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Clean Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' clean '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/clean/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/clean/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { cleanExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Clean Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/clean/executor.ts
+++ b/packages/nx-quarkus/src/executors/clean/executor.ts
@@ -11,6 +11,7 @@ export async function cleanExecutor(
   return runQuarkusPluginCommand('clean', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/clean/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/clean/schema.d.ts
@@ -2,5 +2,6 @@
 export interface CleanExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/clean/schema.json
+++ b/packages/nx-quarkus/src/executors/clean/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Maven or Gradle command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/dev/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/dev/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { devExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Dev Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await devExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/dev/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/dev/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Dev Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' quarkusDev '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await devExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/dev/executor.ts
+++ b/packages/nx-quarkus/src/executors/dev/executor.ts
@@ -11,6 +11,7 @@ export async function devExecutor(
   return runQuarkusPluginCommand('dev', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/dev/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/dev/schema.d.ts
@@ -2,5 +2,6 @@
 export interface DevExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/dev/schema.json
+++ b/packages/nx-quarkus/src/executors/dev/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/format/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('FormatJar Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/format/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/format/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('FormatJar Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' spotlessApply '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/format/executor.ts
+++ b/packages/nx-quarkus/src/executors/format/executor.ts
@@ -11,6 +11,7 @@ export async function formatExecutor(
   return runQuarkusPluginCommand('format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/format/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/format/schema.json
+++ b/packages/nx-quarkus/src/executors/format/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/install/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/install/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Install Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishToMavenLocal '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/install/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/install/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { installExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Install Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/install/executor.ts
+++ b/packages/nx-quarkus/src/executors/install/executor.ts
@@ -11,6 +11,7 @@ export async function installExecutor(
   return runQuarkusPluginCommand('install', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/install/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/install/schema.d.ts
@@ -2,5 +2,6 @@
 export interface InstallExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/install/schema.json
+++ b/packages/nx-quarkus/src/executors/install/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/list-extensions/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/list-extensions/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('List Extensions Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' quarkusListExtensions '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await listExtensionsExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/list-extensions/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/list-extensions/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { listExtensionsExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('List Extensions Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await listExtensionsExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/list-extensions/executor.ts
+++ b/packages/nx-quarkus/src/executors/list-extensions/executor.ts
@@ -11,6 +11,7 @@ export async function listExtensionsExecutor(
   return runQuarkusPluginCommand('list-extensions', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/list-extensions/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/list-extensions/schema.d.ts
@@ -2,5 +2,6 @@
 export interface ListExtensionsExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/list-extensions/schema.json
+++ b/packages/nx-quarkus/src/executors/list-extensions/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/package/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/package/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { packageExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Package Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await packageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/package/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/package/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Package Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' package '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await packageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/package/executor.ts
+++ b/packages/nx-quarkus/src/executors/package/executor.ts
@@ -11,6 +11,7 @@ export async function packageExecutor(
   return runQuarkusPluginCommand('package', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/package/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/package/schema.d.ts
@@ -2,5 +2,6 @@
 export interface PackageExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/package/schema.json
+++ b/packages/nx-quarkus/src/executors/package/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Maven or Gradle command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/remote-dev/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/remote-dev/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { remoteDevExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Run Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await remoteDevExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/remote-dev/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/remote-dev/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Run Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' quarkusRemoteDev '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await remoteDevExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/remote-dev/executor.ts
+++ b/packages/nx-quarkus/src/executors/remote-dev/executor.ts
@@ -11,6 +11,7 @@ export async function remoteDevExecutor(
   return runQuarkusPluginCommand('remote-dev', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/remote-dev/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/remote-dev/schema.d.ts
@@ -2,5 +2,6 @@
 export interface RemoteDevExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/remote-dev/schema.json
+++ b/packages/nx-quarkus/src/executors/remote-dev/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/executors/test/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/test/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { testExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Test Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/test/executor.spec.ts
+++ b/packages/nx-quarkus/src/executors/test/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_QUARKUS_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Test Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' test '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-quarkus/src/executors/test/executor.ts
+++ b/packages/nx-quarkus/src/executors/test/executor.ts
@@ -11,6 +11,7 @@ export async function testExecutor(
   return runQuarkusPluginCommand('test', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-quarkus/src/executors/test/schema.d.ts
+++ b/packages/nx-quarkus/src/executors/test/schema.d.ts
@@ -2,5 +2,6 @@
 export interface TestExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-quarkus/src/executors/test/schema.json
+++ b/packages/nx-quarkus/src/executors/test/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Quarkus command",
       "type": "array",

--- a/packages/nx-quarkus/src/generators/project/generator.spec.ts
+++ b/packages/nx-quarkus/src/generators/project/generator.spec.ts
@@ -152,12 +152,12 @@ describe('project generator', () => {
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        1,
+        2,
         `⬇️ Downloading Quarkus project zip from : ${downloadUrl}...`
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        2,
+        3,
         `📦 Extracting Quarkus project zip to '${workspaceRoot}/${rootDir}/${options.name}'...`
       );
     }
@@ -186,19 +186,27 @@ describe('project generator', () => {
       expect(project.root).toBe(`${projectDir}/${options.name}`);
 
       const commands: BuilderCommandAliasType[] = [
-        'dev',
-        'serve',
-        'remote-dev',
         'test',
         'clean',
         'build',
         'format',
         'apply-format',
         'check-format',
+      ];
+
+      const appOnlyCommands = [ 
+        'dev',
+        'serve',
+        'remote-dev',
         'package',
         'add-extension',
         'list-extensions',
       ];
+
+      if (projectType === 'application') {
+        commands.push(...appOnlyCommands);
+      }
+
       commands.forEach((cmd) => {
         expect(project.targets[cmd].executor).toBe(`${NX_QUARKUS_PKG}:${cmd}`);
         if (['build', 'install', 'test'].includes(cmd)) {

--- a/packages/nx-quarkus/src/generators/project/lib/generate-project-configuration.ts
+++ b/packages/nx-quarkus/src/generators/project/lib/generate-project-configuration.ts
@@ -1,0 +1,85 @@
+import { Tree, addProjectConfiguration, logger } from '@nx/devkit';
+import { NormalizedSchema } from '../schema';
+import {
+  BuilderCommandAliasType,
+  NX_QUARKUS_PKG,
+} from '@nxrocks/common';
+
+export async function generateProjectConfiguration(
+  tree: Tree,
+  options: NormalizedSchema
+): Promise<void> {
+
+  logger.info(
+    `⚙️ Generating project configuration...`
+  );
+
+  const commands: BuilderCommandAliasType[] = [
+    'build',
+    'install',
+    'test',
+    'clean',
+  ];
+
+  if (!options.skipFormat) {
+    commands.push('format', 'apply-format', 'check-format');
+  }
+
+  const parentModuleCommands = [...commands];
+
+  const appOnlyCommands = [ 
+  'dev',
+  'serve',
+  'remote-dev',
+  'package',
+  'add-extension',
+  'list-extensions',
+  ];
+  if (options.projectType === 'application') {
+    //only 'application' projects should have 'quarkus' related commands
+    commands.push(...appOnlyCommands);
+  }
+
+  const getTargets = (commands: string[], rootFolder:string, runFromParentModule?:boolean) => {
+    const targets = {};
+    for (const command of commands) {
+      targets[command] = {
+        executor: `${NX_QUARKUS_PKG}:${command}`,
+        options: {
+          root: rootFolder,
+          ...(runFromParentModule? { runFromParentModule } : {}),
+        },
+        ...(command === 'build' ? { dependsOn: ['^install'] } : {}),
+        ...(['build', 'install', 'test'].includes(command)
+          ? {
+              outputs: [
+                `{workspaceRoot}/${rootFolder}/${
+                  options.buildSystem === 'MAVEN' ? 'target' : 'build'
+                }`,
+              ],
+            }
+          : {}),
+      };
+    }
+    return targets;
+  }
+
+  if(options.transformIntoMultiModule){
+
+    addProjectConfiguration(tree, options.parentModuleName, {
+      root: options.moduleRoot,
+      sourceRoot: `${options.moduleRoot}`,
+      projectType: options.projectType,
+      targets: getTargets(parentModuleCommands, options.moduleRoot, false),
+      tags: options.parsedTags,
+    });
+  }
+
+  addProjectConfiguration(tree, options.projectName, {
+    root: options.projectRoot,
+    sourceRoot: `${options.projectRoot}/src`,
+    projectType: options.projectType,
+    targets: getTargets(commands, options.projectRoot, !options.keepProjectLevelWrapper),
+    tags: options.parsedTags,
+  });
+}

--- a/packages/nx-quarkus/src/generators/project/lib/generate-quarkus-project.ts
+++ b/packages/nx-quarkus/src/generators/project/lib/generate-quarkus-project.ts
@@ -6,6 +6,8 @@ import { buildQuarkusDownloadUrl } from '../../../utils/quarkus-utils';
 import {
   extractFromZipStream,
   getCommonHttpHeaders,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
   NX_QUARKUS_PKG,
 } from '@nxrocks/common';
 
@@ -33,9 +35,24 @@ export async function generateQuarkusProject(
         filePath.endsWith('mvnw') || filePath.endsWith('gradlew')
           ? '755'
           : undefined;
-      tree.write(`${options.projectRoot}/${filePath}`, entryContent, {
-        mode: execPermission,
-      });
+        if (getMavenWrapperFiles().includes(filePath) || getGradleWrapperFiles().includes(filePath)) {
+          if (options.transformIntoMultiModule) {
+            tree.write(`${options.moduleRoot}/${filePath}`, entryContent, {
+              mode: execPermission,
+            });
+          }
+          if (options.keepProjectLevelWrapper) {
+            tree.write(`${options.projectRoot}/${filePath}`, entryContent, {
+              mode: execPermission,
+            });
+          }
+  
+        }
+        else {
+          tree.write(`${options.projectRoot}/${filePath}`, entryContent, {
+            mode: execPermission,
+          });
+        }
     });
   } else {
     throw new Error(stripIndents`

--- a/packages/nx-quarkus/src/generators/project/lib/index.ts
+++ b/packages/nx-quarkus/src/generators/project/lib/index.ts
@@ -1,5 +1,7 @@
  export { generateQuarkusProject } from './generate-quarkus-project';
+ export { generateProjectConfiguration} from './generate-project-configuration';
  export { addFormattingWithSpotless } from './add-formatting-with-spotless';
  export { addMavenPublishPlugin } from './add-maven-publish-plugin';
  export { normalizeOptions } from './normalize-options';
  export { promptQuarkusExtensions } from './prompt-quarkus-extensions';
+ export { promptForMultiModuleSupport } from './prompt-multi-module-support';

--- a/packages/nx-quarkus/src/generators/project/lib/prompt-multi-module-support.ts
+++ b/packages/nx-quarkus/src/generators/project/lib/prompt-multi-module-support.ts
@@ -1,0 +1,117 @@
+import { logger, createProjectGraphAsync, ProjectGraph, Tree, readCachedProjectGraph } from "@nx/devkit";
+import { prompt } from 'enquirer';
+
+import { NormalizedSchema } from "../schema";
+import { addGradleModule, addMavenModule, initGradleParentModule, initMavenParentModule, hasMultiModuleGradleProjectInTree, hasMultiModuleMavenProjectInTree } from "@nxrocks/common";
+
+export async function promptForMultiModuleSupport(tree: Tree, options: NormalizedSchema) {
+
+    const buildSystemName = options.buildSystem === 'MAVEN' ? 'Maven' : 'Gradle';
+    if (
+        (options.transformIntoMultiModule === undefined || options.addToExistingParentModule === undefined) &&
+        options.parentModuleName === undefined &&
+        process.env.NX_INTERACTIVE === 'true'
+    ) {
+        logger.info(`⏳ Checking for existing multi-module projects. Please wait...`);
+
+        const projectGraph: ProjectGraph = await createProjectGraphAsync();
+
+        const multiModuleProjects = Object.values(projectGraph.nodes).map(n => n.data).filter(project => options.buildSystem === 'MAVEN' ? hasMultiModuleMavenProjectInTree(tree, project.root) : hasMultiModuleGradleProjectInTree(tree, project.root))
+
+        if (multiModuleProjects.length === 0) {
+            options.transformIntoMultiModule = await prompt({
+                name: 'transformIntoMultiModule',
+                message:
+                    `Would you like to transform the generated project into a ${buildSystemName} multi-module project?`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['transformIntoMultiModule']);
+
+            if (options.transformIntoMultiModule) {
+                options.parentModuleName = (await prompt({
+                    name: 'parentModuleName',
+                    message:
+                        `What name would you like to use for the ${buildSystemName} multi-module project?`,
+                    type: 'input',
+                    initial: `${options.projectName}-parent`
+                }).then((a) => a['parentModuleName'])).replace(/\//g, '-');
+
+                options.keepProjectLevelWrapper = await prompt({
+                    name: 'keepProjectLevelWrapper',
+                    message:
+                        `A root ${buildSystemName} wrapper will be added in the root module '${options.parentModuleName}'. Do you want to keep the one in the generated child module '${options.projectName}'?`,
+                    type: 'confirm',
+                    initial: false
+                }).then((a) => a['keepProjectLevelWrapper']);
+            }
+        }
+        else {
+            options.addToExistingParentModule = await prompt({
+                name: 'addToExistingParentModule',
+                message:
+                `We found ${multiModuleProjects.length} existing ${buildSystemName} multi-module projects in your workaspace${multiModuleProjects.length === 1 ? `('${multiModuleProjects[0].name}')` : ''}.\nWould you like to add this new project ${multiModuleProjects.length === 1 ? 'to it?' : 'into one of them?'}`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['addToExistingParentModule']);
+
+            if (options.addToExistingParentModule) {
+                if (multiModuleProjects.length === 1) {
+                    options.parentModuleName = multiModuleProjects[0].name;
+                }
+                else {
+                    options.parentModuleName = await prompt({
+                        name: 'parentModuleName',
+                        message:
+                        'Which parent module would you like to add the new project into?',
+                        type: 'select',
+                        choices: multiModuleProjects.map(p => p.name),
+                    }).then((a) => a['parentModuleName']);
+                }
+            }
+
+        }
+    }
+
+    if((options.transformIntoMultiModule || options.addToExistingParentModule) && options.parentModuleName){
+        const helpComment = `For more information about ${buildSystemName} multi-modules projects, go to: ${options.buildSystem === 'MAVEN' ? 'https://maven.apache.org/guides/mini/guide-multiple-modules-4.html' : 'https://docs.gradle.org/current/userguide/intro_multi_project_builds.html'}`;
+
+        await adjustOptionsForMultiModules(options);
+
+        if(options.transformIntoMultiModule){
+            // add the root module
+            if(options.buildSystem === 'MAVEN'){
+                initMavenParentModule(tree, options.moduleRoot, options.groupId, options.parentModuleName, options.projectName, `<!-- ${helpComment} -->`);
+            }
+            else {
+                initGradleParentModule(tree, options.moduleRoot, options.parentModuleName, options.projectName, options. buildSystem === 'GRADLE_KOTLIN_DSL', `// ${helpComment}`);
+            }
+        }
+        else if(options.addToExistingParentModule){
+            // add to the chosen root module
+            if(options.buildSystem === 'MAVEN'){
+                addMavenModule(tree, options.moduleRoot, options.projectName);
+            }
+            else {
+                addGradleModule(tree, options.moduleRoot, options.projectName, options. buildSystem === 'GRADLE_KOTLIN_DSL');
+            }
+        }
+    }
+}
+
+async function adjustOptionsForMultiModules(options: NormalizedSchema) {
+
+    const projectGraph: ProjectGraph = process.env.NX_INTERACTIVE === 'true' ? readCachedProjectGraph() : await createProjectGraphAsync();
+
+    if(options.addToExistingParentModule && !projectGraph.nodes[options.parentModuleName]){
+        throw new Error(`No parent module project named '${options.parentModuleName}' was found in this workspace! Make sure the project exists.`);
+    }
+    const lastIndexOfPathSlash = options.projectRoot.lastIndexOf('/');
+    if(options.addToExistingParentModule){
+        options.moduleRoot = projectGraph.nodes[options.parentModuleName].data.root;
+    }
+    else {
+        const rootFolder = options.projectRoot.substring(0, lastIndexOfPathSlash);
+        options.moduleRoot = `${rootFolder}/${options.parentModuleName}`;
+    }
+    options.projectRoot = `${options.moduleRoot}/${options.projectRoot.substring(lastIndexOfPathSlash + 1)}`;
+}

--- a/packages/nx-quarkus/src/generators/project/schema.d.ts
+++ b/packages/nx-quarkus/src/generators/project/schema.d.ts
@@ -14,6 +14,11 @@ export interface ProjectGeneratorOptions {
   extensions?: string;
   version?: string;
   skipFormat?: boolean;
+
+  transformIntoMultiModule?: boolean;
+  addToExistingParentModule?: boolean;
+  parentModuleName?: string;
+  keepProjectLevelWrapper?: boolean;
 }
 
 export interface NormalizedSchema extends ProjectGeneratorOptions {
@@ -22,4 +27,5 @@ export interface NormalizedSchema extends ProjectGeneratorOptions {
   projectDirectory: string;
   projectExtensions: string[];
   parsedTags: string[];
+  moduleRoot?: string;
 }

--- a/packages/nx-quarkus/src/generators/project/schema.json
+++ b/packages/nx-quarkus/src/generators/project/schema.json
@@ -87,6 +87,23 @@
       "type": "string",
       "x-priority": "important"
     },
+    "transformIntoMultiModule": {
+      "description": "Transform the project into a multi-module project. Follow this guide https://t.ly/TmKF- for more information.",
+      "type": "boolean"
+    },
+    "addToExistingParentModule": {
+      "description": "Add the project into an existing parent module project. Follow this guide https://t.ly/TmKF- for more information.",
+      "type": "boolean"
+    },
+    "parentModuleName": {
+      "description": "Name of the parent module to create or to add child project into.",
+      "type": "string"
+    },
+    "keepProjectLevelWrapper": {
+      "description": "Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Follow this guide https://t.ly/TmKF- for more information.",
+      "type": "boolean",
+      "default": true
+    },
     "quarkusInitializerUrl": {
       "type": "string",
       "default": "https://code.quarkus.io",

--- a/packages/nx-quarkus/src/utils/quarkus-utils.ts
+++ b/packages/nx-quarkus/src/utils/quarkus-utils.ts
@@ -9,6 +9,8 @@ import {
   runBuilderCommand,
   getCommonHttpHeaders,
   NX_QUARKUS_PKG,
+  hasMultiModuleGradleProject,
+  hasMultiModuleMavenProject,
 } from '@nxrocks/common';
 
 import { MAVEN_BUILDER, GRADLE_BUILDER } from '../core/constants';
@@ -38,7 +40,7 @@ export interface QuarkusExtension {
 export function runQuarkusPluginCommand(
   commandAlias: BuilderCommandAliasType,
   params: string[],
-  options: { cwd?: string; ignoreWrapper?: boolean } = { ignoreWrapper: false }
+  options: { cwd: string; ignoreWrapper?: boolean, runFromParentModule?: boolean } = { cwd: process.cwd(), ignoreWrapper: false, runFromParentModule: false }
 ): { success: boolean } {
   return runBuilderCommand(commandAlias, getBuilder, params, options);
 }
@@ -64,6 +66,9 @@ export function buildQuarkusDownloadUrl(options: NormalizedSchema) {
 }
 
 export function isQuarkusProject(project: ProjectConfiguration): boolean {
+  if(hasMultiModuleMavenProject(project.root) || hasMultiModuleGradleProject(project.root))
+    return true;
+
   if (isMavenProject(project)) {
     return checkProjectBuildFileContains(project, {
       fragments: [

--- a/packages/nx-spring-boot/README.md
+++ b/packages/nx-spring-boot/README.md
@@ -22,11 +22,12 @@ Here is a list of some of the coolest features of the plugin:
 
 - ✅ Generation of Spring Boot applications/libraries based on **Spring Initializr** API
 - ✅ Building, packaging, testing, etc your Spring Boot projects
-- ✅ Code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for Maven or Gradle
-- ✅ Support for corporate proxies (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
-- ✅ Integration with Nx's **dependency graph** (through `nx dep-graph` or `nx affected:dep-graph`): this allows you to **visualize** the dependencies of any Spring Boot's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
+- ✅ 🆕 Built-in support for creating [**multi-modules**](recipes/README.md#creating-mulit-modules-spring-boot-projects) Spring Boot projects with both `Maven` and `Gradle`
+- ✅ Built-in support for code formatting using the excellent [**Spotless**](https://github.com/diffplug/spotless) plugin for `Maven` or `Gradle`
+- ✅ Built-in support for **corporate proxies** (either via `--proxyUrl` or by defining environment variable `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`)
+- ✅ Integration with Nx's **dependency graph** (through `nx graph` or `nx affected:graph`): this allows you to **visualize** the dependencies of any Spring Boot's `Maven`/`Gradle` applications or libraries inside your workspace, just like Nx natively does it for JS/TS-based projects!
   ![Nx Spring Boot dependency graph](https://raw.githubusercontent.com/tinesoft/nxrocks/develop/images/nx-spring-boot-dep-graph.png)
-  _Example of running the `nx dep-graph` command on a workspace with 2 Spring Boot projects inside_
+  _Example of running the `nx graph` command on a workspace with 2 Spring Boot projects inside_
 
 - ...
 
@@ -82,24 +83,28 @@ Here the list of available generation options :
 | --------- | ------------------------- |
 | `<name>`  | The name of your project. |
 
-| Option                 | Value                               | Description                                                                                                          |
-| ---------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `projectType`          | `application` \| `library`          | Type of project to generate                                                                                          |
-| `buildSystem`          | `maven-project` \| `gradle-project` | Build system                                                                                                         |
-| `packaging`            | `jar` \| `war`                      | Packaging to use                                                                                                     |
-| `javaVersion`          | `8` \| `11` \| `15`                 | Java version to use                                                                                                  |
-| `language`             | `java` \| `groovy` \| `kotlin`      | Language to use                                                                                                      |
-| `groupId`              | `string`                            | GroupId of the project                                                                                               |
-| `artifactId`           | `string`                            | ArtifactId of the project                                                                                            |
-| `packageName`          | `string`                            | Main package name                                                                                                    |
-| `description`          | `string`                            | Description of the project                                                                                           |
-| `skipFormat`           | `boolean`                           | Do not add the ability to format code (using Spotless plugin)                                                        |
-| `dependencies`         | `string`                            | List of dependencies to use (comma-separated). Go to https://start.spring.io/dependencies to get the ids needed here |
-| `springInitializerUrl` | `https://start.spring.io`           | URL to the Spring Initializer instance to use                                                                        |
-| `proxyUrl`             |                                     | The URL of the (corporate) proxy server to use to access Spring Initializr                                           |
-| `bootVersion`          | `string`                            | Spring Boot version to use                                                                                           |
-| `tags`                 | `string`                            | Tags to use for linting (comma-separated)                                                                            |
-| `directory`            | `string`                            | Directory where the project is placed                                                                                |
+| Option                     | Value                               | Description                                                                                                          |
+| -------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `projectType`              | `application` \| `library`          | Type of project to generate                                                                                          |
+| `buildSystem`              | `maven-project` \| `gradle-project` | Build system                                                                                                         |
+| `packaging`                | `jar` \| `war`                      | Packaging to use                                                                                                     |
+| `javaVersion`              | `8` \| `11` \| `15`                 | Java version to use                                                                                                  |
+| `language`                 | `java` \| `groovy` \| `kotlin`      | Language to use                                                                                                      |
+| `groupId`                  | `string`                            | GroupId of the project                                                                                               |
+| `artifactId`               | `string`                            | ArtifactId of the project                                                                                            |
+| `packageName`              | `string`                            | Main package name                                                                                                    |
+| `description`              | `string`                            | Description of the project                                                                                           |
+| `skipFormat`               | `boolean`                           | Do not add the ability to format code (using Spotless plugin)                                                        |
+| `dependencies`             | `string`                            | List of dependencies to use (comma-separated). Go to [recipes](recipes/README.md#adding-spring-boot-dependencies) for more information               |
+| `transformIntoMultiModule` | `boolean`                           | Transform the project into a multi-module project. Go to [recipes](recipes/README.md#creating-mulit-modules-spring-boot-projects) for more information               |
+| `addToExistingParentModule`| `boolean`                           | Add the project into an existing parent module project. Go to [recipes](recipes/README.md#creating-mulit-modules-spring-boot-projects) for more information               |
+| `parentModuleName`         | `string`                            | Name of the parent module to create or to add child project into. Go to [recipes](recipes/README.md#creating-mulit-modules-spring-boot-projects) for more information               |
+| `keepProjectLevelWrapper`  | `boolean`                           | Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Go to [recipes](recipes/README.md#creating-mulit-modules-spring-boot-projects) for more information               |
+| `springInitializerUrl`     | `https://start.spring.io`           | URL to the Spring Initializer instance to use                                                                        |
+| `proxyUrl`                 |                                     | The URL of the (corporate) proxy server to use to access Spring Initializr                                           |
+| `bootVersion`              | `string`                            | Spring Boot version to use                                                                                           |
+| `tags`                     | `string`                            | Tags to use for linting (comma-separated)                                                                            |
+| `directory`                | `string`                            | Directory where the project is placed                                                                                |
 
 > **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
 > Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Spring Initializer to generate the project.
@@ -146,17 +151,17 @@ Once your app is generated, you can now use buidlers to manage it.
 
 Here the list of available executors:
 
-| Executor                      | Arguments                                 | Description                                                                                                                                                      |
-| ----------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run` \| `serve`<sup>\*</sup> | `ignoreWrapper:boolean`, `args: string[]` | Runs the project using either `./mvnw\|mvn spring-boot:run` or `./gradlew\|gradle bootRun`                                                                       |
-| `test`                        | `ignoreWrapper:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                    |
-| `clean`                       | `ignoreWrapper:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                 |
-| `format`                      | `ignoreWrapper:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                             |
-| `check-format`                | `ignoreWrapper:boolean`, `args: string[]` | Check whether the project is well formatted using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                    |
-| `build`                       | `ignoreWrapper:boolean`, `args: string[]` | Packages the project into an executable Jar using either `./mvnw\|mvn package` or `./gradlew\|gradle build`                                                      |
-| `install`                     | `ignoreWrapper:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
-| `build-info`<sup>\*</sup>     | `ignoreWrapper:boolean`,                  | Generates a `build-info.properties` using either `./mvnw\|mvn spring-boot:build-info` or `./gradlew\|gradle bootBuildInfo`                                       |
-| `build-image`<sup>\*</sup>    | `ignoreWrapper:boolean`, `args: string[]` | Generates an [OCI Image](https://github.com/opencontainers/image-spec) using either `./mvnw\|mvn spring-boot:build-image` or `./gradlew\|gradle bootBuildImage`  |
+| Executor                      | Arguments                                                                | Description                                                                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run` \| `serve`<sup>\*</sup> | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Runs the project using either `./mvnw\|mvn spring-boot:run` or `./gradlew\|gradle bootRun`                                                                       |
+| `test`                        | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Tests the project using either `./mvnw\|mvn test` or `./gradlew\|gradle test`                                                                                    |
+| `clean`                       | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Cleans the project using either `./mvnw\|mvn clean` or `./gradlew\|gradle clean`                                                                                 |
+| `format`                      | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Format the project using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                                             |
+| `check-format`                | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Check whether the project is well formatted using [Spotless](https://github.com/diffplug/spotless) plugin for Maven or Gradle                                    |
+| `build`                       | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Packages the project into an executable Jar using either `./mvnw\|mvn package` or `./gradlew\|gradle build`                                                      |
+| `install`                     | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Installs the project's artifacts to local Maven repository (in `~/.m2/repository`) using either `./mvnw\|mvn install` or `./gradlew\|gradle publishToMavenLocal` |
+| `build-info`<sup>\*</sup>     | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Generates a `build-info.properties` using either `./mvnw\|mvn spring-boot:build-info` or `./gradlew\|gradle bootBuildInfo`                                       |
+| `build-image`<sup>\*</sup>    | `ignoreWrapper:boolean`, `runFromParentModule:boolean`, `args: string[]` | Generates an [OCI Image](https://github.com/opencontainers/image-spec) using either `./mvnw\|mvn spring-boot:build-image` or `./gradlew\|gradle bootBuildImage`  |
 
 In order to execute the requested command, each executor will use, by default, the embedded `./mvnw` or `./gradlew` executable, that was generated alongside the project.
 If you want to rely on a globally installed `mvn` or `gradle` executable instead, add the `--ignoreWrapper` option to bypass it.

--- a/packages/nx-spring-boot/recipes/README.md
+++ b/packages/nx-spring-boot/recipes/README.md
@@ -18,3 +18,16 @@ You will need to fetch and enter the dependencies ids manually:
 
 3. In Nx Console UI, enter the dependencies ids you want to use, separated by a comma
 ![Adding dependencies in Nx Console](images/nx-console-add-dependencies.png)
+
+
+## Creating mulit-modules Spring Boot projects
+
+The support for creating multi-module Spring Boot project with either `Maven` or `Gradle` was added to the plugin since `v8.1.0`.
+
+When generating a new project, you can now choose either to:
+
+* Transform the project being generated into a multi-module project by setting `transformIntoMultiModule` to `true` and by providing the name of the parent module to create on top of the child project, via `parentModuleName` option.
+* Add the project being generated into an existing multi-module project by setting `addToExistingParentModule` to `true` and by providing the name of the parent module to add the child project too.
+
+> **Note** When running the `@nxrocks/nx-spring-boot:project` generator in **interactive mode** (i.e via command line),
+> we can automatically analyze your workspace and prompt for the appropriate above options to add multi-module support.

--- a/packages/nx-spring-boot/src/executors/build-image/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/build-image/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,10 @@ describe('BuildImage Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' bootBuildImage '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildImageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/build-image/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/build-image/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { buildImageExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('BuildImage Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildImageExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/build-image/executor.ts
+++ b/packages/nx-spring-boot/src/executors/build-image/executor.ts
@@ -11,6 +11,7 @@ export async function buildImageExecutor(
   return runBootPluginCommand('build-image', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/build-image/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/build-image/schema.d.ts
@@ -2,5 +2,6 @@
 export interface BuildImageExecutorOptions{
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/build-image/schema.json
+++ b/packages/nx-spring-boot/src/executors/build-image/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/build-info/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/build-info/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,10 @@ describe('BuildInfo Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' bootBuildInfo '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildInfoExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/build-info/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/build-info/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { buildInfoExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('BuildInfo Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildInfoExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/build-info/executor.ts
+++ b/packages/nx-spring-boot/src/executors/build-info/executor.ts
@@ -11,6 +11,7 @@ export async function buildInfoExecutor(
   return runBootPluginCommand('build-info', [], {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/build-info/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/build-info/schema.d.ts
@@ -2,4 +2,5 @@
 export interface BuildInfoExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
 }

--- a/packages/nx-spring-boot/src/executors/build-info/schema.json
+++ b/packages/nx-spring-boot/src/executors/build-info/schema.json
@@ -14,6 +14,16 @@
       "description": "Whether or not to use the embedded wrapper (`mvnw`or `gradlew`) to perfom build operations",
       "type": "boolean",
       "default": false
+    },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
+    "args": {
+      "description": "The argument to be passed to the underlying Spring Boot command",
+      "type": "array",
+      "default": []
     }
   },
   "required": []

--- a/packages/nx-spring-boot/src/executors/build/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/build/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { buildExecutor } from './executor';
@@ -50,7 +50,7 @@ describe('Build Executor', () => {
 
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/build/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/build/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,11 @@ describe('Build Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' build '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await buildExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/build/executor.ts
+++ b/packages/nx-spring-boot/src/executors/build/executor.ts
@@ -11,6 +11,7 @@ export async function buildExecutor(
   return runBootPluginCommand('build', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/build/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/build/schema.d.ts
@@ -2,5 +2,6 @@
 export interface BuildExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/build/schema.json
+++ b/packages/nx-spring-boot/src/executors/build/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/check-format/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/check-format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatCheckExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('Format Check Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatCheckExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/check-format/executor.ts
+++ b/packages/nx-spring-boot/src/executors/check-format/executor.ts
@@ -11,6 +11,7 @@ export async function formatCheckExecutor(
   return runBootPluginCommand('check-format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/check-format/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/check-format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatCheckExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/check-format/schema.json
+++ b/packages/nx-spring-boot/src/executors/check-format/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/clean/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/clean/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { cleanExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('Clean Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/clean/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/clean/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,10 @@ describe('Clean Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' clean '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await cleanExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/clean/executor.ts
+++ b/packages/nx-spring-boot/src/executors/clean/executor.ts
@@ -11,6 +11,7 @@ export async function cleanExecutor(
   return runBootPluginCommand('clean', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/clean/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/clean/schema.d.ts
@@ -2,5 +2,6 @@
 export interface CleanExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/clean/schema.json
+++ b/packages/nx-spring-boot/src/executors/clean/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Maven or Gradle command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/format/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/format/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { formatExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('Format Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await formatExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/format/executor.ts
+++ b/packages/nx-spring-boot/src/executors/format/executor.ts
@@ -11,6 +11,7 @@ export async function formatExecutor(
   return runBootPluginCommand('format', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/format/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/format/schema.d.ts
@@ -2,5 +2,6 @@
 export interface FormatExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/format/schema.json
+++ b/packages/nx-spring-boot/src/executors/format/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/install/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/install/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { installExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('Install Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/install/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/install/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,10 @@ describe('Install Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' publishToMavenLocal '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await installExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/install/executor.ts
+++ b/packages/nx-spring-boot/src/executors/install/executor.ts
@@ -11,6 +11,7 @@ export async function installExecutor(
   return runBootPluginCommand('install', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/install/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/install/schema.d.ts
@@ -2,5 +2,6 @@
 export interface InstallExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/install/schema.json
+++ b/packages/nx-spring-boot/src/executors/install/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/run/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/run/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { runExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('Run Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await runExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/run/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/run/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,10 @@ describe('Run Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' bootRun '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await runExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/run/executor.ts
+++ b/packages/nx-spring-boot/src/executors/run/executor.ts
@@ -11,6 +11,7 @@ export async function runExecutor(
   return runBootPluginCommand('run', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/run/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/run/schema.d.ts
@@ -2,5 +2,6 @@
 export interface RunExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/run/schema.json
+++ b/packages/nx-spring-boot/src/executors/run/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/serve/schema.json
+++ b/packages/nx-spring-boot/src/executors/serve/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/executors/test/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/test/executor.spec.ts
@@ -7,6 +7,8 @@ import {
   GRADLE_WRAPPER_EXECUTABLE,
   MAVEN_WRAPPER_EXECUTABLE,
   NX_SPRING_BOOT_PKG,
+  getGradleWrapperFiles,
+  getMavenWrapperFiles,
 } from '@nxrocks/common';
 import {
   expectExecutorCommandRanWith,
@@ -44,9 +46,10 @@ describe('Test Executor', () => {
     ${false}      | ${'gradle'} | ${'build.gradle'} | ${GRADLE_WRAPPER_EXECUTABLE + ' test '}
   `(
     'should execute a $buildSystem build and ignoring wrapper : $ignoreWrapper',
-    async ({ ignoreWrapper, buildFile, execute }) => {
+    async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
+      const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => filePath.indexOf(buildFile) !== -1
+        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/test/executor.spec.ts
+++ b/packages/nx-spring-boot/src/executors/test/executor.spec.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nx/devkit';
+import { joinPathFragments, logger } from '@nx/devkit';
 import { mocked } from 'jest-mock';
 
 import { testExecutor } from './executor';
@@ -49,7 +49,7 @@ describe('Test Executor', () => {
     async ({ ignoreWrapper, buildSystem, buildFile, execute }) => {
       const files = [buildFile as string, ...(buildSystem === 'maven'? getMavenWrapperFiles() : getGradleWrapperFiles())];
       mocked(fsUtility.fileExists).mockImplementation(
-        (filePath: string) => files.some( (f)=> filePath.endsWith(f))
+        (filePath: string) => files.some((f) => joinPathFragments(filePath).endsWith(f))
       );
 
       await testExecutor({ ...options, ignoreWrapper }, mockContext);

--- a/packages/nx-spring-boot/src/executors/test/executor.ts
+++ b/packages/nx-spring-boot/src/executors/test/executor.ts
@@ -11,6 +11,7 @@ export async function testExecutor(
   return runBootPluginCommand('test', options.args, {
     cwd: root,
     ignoreWrapper: options.ignoreWrapper,
+    runFromParentModule: options.runFromParentModule,
   });
 }
 

--- a/packages/nx-spring-boot/src/executors/test/schema.d.ts
+++ b/packages/nx-spring-boot/src/executors/test/schema.d.ts
@@ -2,5 +2,6 @@
 export interface TestExecutorOptions {
     root: string;
     ignoreWrapper?: boolean;
+    runFromParentModule?: boolean;
     args?: string[];
 }

--- a/packages/nx-spring-boot/src/executors/test/schema.json
+++ b/packages/nx-spring-boot/src/executors/test/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false
     },
+    "runFromParentModule": {
+      "description": "Whether or not to run the (child) module from the context of its parent",
+      "type": "boolean",
+      "default": false
+    },
     "args": {
       "description": "The argument to be passed to the underlying Spring Boot command",
       "type": "array",

--- a/packages/nx-spring-boot/src/generators/project/generator.spec.ts
+++ b/packages/nx-spring-boot/src/generators/project/generator.spec.ts
@@ -184,12 +184,12 @@ describe('project generator', () => {
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        1,
+        2,
         `⬇️ Downloading Spring Boot project zip from : ${downloadUrl}...`
       );
 
       expect(logger.info).toHaveBeenNthCalledWith(
-        2,
+        3,
         `📦 Extracting Spring Boot project zip to '${workspaceRoot}/${rootDir}/${options.name}'...`
       );
 

--- a/packages/nx-spring-boot/src/generators/project/lib/generate-project-configuration.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/generate-project-configuration.ts
@@ -1,0 +1,80 @@
+import { Tree, addProjectConfiguration, logger } from '@nx/devkit';
+import { NormalizedSchema } from '../schema';
+import {
+  BuilderCommandAliasType,
+  NX_SPRING_BOOT_PKG,
+} from '@nxrocks/common';
+
+export async function generateProjectConfiguration(
+  tree: Tree,
+  options: NormalizedSchema
+): Promise<void> {
+
+  logger.info(
+    `⚙️ Generating project configuration...`
+  );
+
+  const commands: BuilderCommandAliasType[] = [
+    'build',
+    'install',
+    'test',
+    'clean',
+  ];
+
+  if (!options.skipFormat) {
+    commands.push('format', 'apply-format', 'check-format');
+  }
+
+  const parentModuleCommands = [...commands];
+
+  const appOnlyCommands = ['run', 'serve', 'build-image', 'build-info'];
+  if (options.projectType === 'application') {
+    //only 'application' projects should have 'boot' related commands
+    commands.push(...appOnlyCommands);
+  }
+
+  const getTargets = (commands: string[], rootFolder:string, runFromParentModule?:boolean) => {
+    const targets = {};
+    for (const command of commands) {
+      targets[command] = {
+        executor: `${NX_SPRING_BOOT_PKG}:${command}`,
+        options: {
+          root: rootFolder,
+          ...(runFromParentModule? { runFromParentModule } : {}),
+        },
+        ...(command === 'build' ? { dependsOn: ['^install'] } : {}),
+        ...(['build', 'build-image', 'install', 'test'].includes(command)
+          ? {
+              outputs: [
+                `{workspaceRoot}/${rootFolder}/${
+                  options.buildSystem === 'maven-project'
+                    ? 'target'
+                    : 'build'
+                }`,
+              ],
+            }
+          : {}),
+      };
+    }
+    return targets;
+  }
+
+  if(options.transformIntoMultiModule){
+
+    addProjectConfiguration(tree, options.parentModuleName, {
+      root: options.moduleRoot,
+      sourceRoot: `${options.moduleRoot}`,
+      projectType: options.projectType,
+      targets: getTargets(parentModuleCommands, options.moduleRoot, false),
+      tags: options.parsedTags,
+    });
+  }
+
+  addProjectConfiguration(tree, options.projectName, {
+    root: options.projectRoot,
+    sourceRoot: `${options.projectRoot}/src`,
+    projectType: options.projectType,
+    targets: getTargets(commands, options.projectRoot, !options.keepProjectLevelWrapper),
+    tags: options.parsedTags,
+  });
+}

--- a/packages/nx-spring-boot/src/generators/project/lib/index.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/index.ts
@@ -6,3 +6,5 @@
  export { addMavenPublishPlugin } from './add-maven-publish-plugin';
  export { promptBootDependencies } from './prompt-boot-dependencies';
  export { normalizeOptions } from './normalize-options';
+ export { promptForMultiModuleSupport } from './prompt-multi-module-support';
+ export { generateProjectConfiguration} from './generate-project-configuration';

--- a/packages/nx-spring-boot/src/generators/project/lib/prompt-multi-module-support.ts
+++ b/packages/nx-spring-boot/src/generators/project/lib/prompt-multi-module-support.ts
@@ -1,0 +1,116 @@
+import { logger, createProjectGraphAsync, ProjectGraph, Tree, readCachedProjectGraph } from "@nx/devkit";
+import { prompt } from 'enquirer';
+
+import { NormalizedSchema } from "../schema";
+import { addGradleModule, addMavenModule, initGradleParentModule, initMavenParentModule, hasMultiModuleGradleProjectInTree, hasMultiModuleMavenProjectInTree } from "@nxrocks/common";
+
+export async function promptForMultiModuleSupport(tree: Tree, options: NormalizedSchema) {
+    if (
+        (options.transformIntoMultiModule === undefined || options.addToExistingParentModule === undefined) &&
+        options.parentModuleName === undefined &&
+        process.env.NX_INTERACTIVE === 'true'
+    ) {
+        logger.info(`⏳ Checking for existing multi-module projects. Please wait...`);
+
+        const projectGraph: ProjectGraph = await createProjectGraphAsync();
+
+        const multiModuleProjects = Object.values(projectGraph.nodes).map(n => n.data).filter(project => options.buildSystem === 'maven-project' ? hasMultiModuleMavenProjectInTree(tree, project.root) : hasMultiModuleGradleProjectInTree(tree, project.root))
+        const buildSystemName = options.buildSystem === 'maven-project' ? 'Maven' : 'Gradle';
+
+        if (multiModuleProjects.length === 0) {
+            options.transformIntoMultiModule = await prompt({
+                name: 'transformIntoMultiModule',
+                message:
+                    `Would you like to transform the generated project into a ${buildSystemName} multi-module project?`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['transformIntoMultiModule']);
+
+            if (options.transformIntoMultiModule) {
+                options.parentModuleName = (await prompt({
+                    name: 'multiModuleName',
+                    message:
+                        `What name would you like to use for the ${buildSystemName} multi-module project?`,
+                    type: 'input',
+                    initial: `${options.projectName}-parent`
+                }).then((a) => a['multiModuleName'])).replace(/\//g, '-');
+
+                options.keepProjectLevelWrapper = await prompt({
+                    name: 'keepProjectLevelBuildSystemWrapper',
+                    message:
+                        `A root ${buildSystemName} wrapper will be added in the root module '${options.parentModuleName}'. Do you want to keep the one in the generated child module '${options.projectName}'?`,
+                    type: 'confirm',
+                    initial: false
+                }).then((a) => a['keepProjectLevelBuildSystemWrapper']);
+            }
+        }
+        else {
+            options.addToExistingParentModule = await prompt({
+                name: 'addToExistingParentModule',
+                message:
+                    `We found ${multiModuleProjects.length} existing ${buildSystemName} multi-module projects in your workaspace${multiModuleProjects.length === 1 ? `('${multiModuleProjects[0].name}')` : ''}.\nWould you like to add this new project ${multiModuleProjects.length === 1 ? 'to it?' : 'into one of them?'}`,
+                type: 'confirm',
+                initial: false
+            }).then((a) => a['addToExistingParentModule']);
+
+            if (options.addToExistingParentModule) {
+                if (multiModuleProjects.length === 1) {
+                    options.parentModuleName = multiModuleProjects[0].name;
+                }
+                else {
+                    options.parentModuleName = await prompt({
+                        name: 'parentModuleName',
+                        message:
+                            'Which parent module would you like to add the new project into?',
+                        type: 'select',
+                        choices: multiModuleProjects.map(p => p.name),
+                    }).then((a) => a['parentModuleName']);
+                }
+            }
+
+        }
+    }
+
+    if((options.transformIntoMultiModule || options.addToExistingParentModule) && options.parentModuleName){
+        const helpComment = 'For more information about Spring boot multi-modules projects, go to: https://spring.io/guides/gs/multi-module/';
+
+        await adjustOptionsForMultiModules(options);
+
+        if(options.transformIntoMultiModule){
+            // add the root module
+            if(options.buildSystem === 'maven-project'){
+                initMavenParentModule(tree, options.moduleRoot, options.groupId, options.parentModuleName, options.projectName, `<!-- ${helpComment} -->`);
+            }
+            else {
+                initGradleParentModule(tree, options.moduleRoot, options.parentModuleName, options.projectName, options. buildSystem === 'gradle-project-kotlin', `// ${helpComment}`);
+            }
+        }
+        else if(options.addToExistingParentModule){
+            // add to the chosen root module
+            if(options.buildSystem === 'maven-project'){
+                addMavenModule(tree, options.moduleRoot, options.projectName);
+            }
+            else {
+                addGradleModule(tree, options.moduleRoot, options.projectName, options. buildSystem === 'gradle-project-kotlin');
+            }
+        }
+    }
+}
+
+async function adjustOptionsForMultiModules(options: NormalizedSchema) {
+
+    const projectGraph: ProjectGraph = process.env.NX_INTERACTIVE === 'true' ? readCachedProjectGraph() : await createProjectGraphAsync();
+
+    if(options.addToExistingParentModule && !projectGraph.nodes[options.parentModuleName]){
+        throw new Error(`No parent module project named '${options.parentModuleName}' was found in this workspace! Make sure the project exists.`);
+    }
+    const lastIndexOfPathSlash = options.projectRoot.lastIndexOf('/');
+    if(options.addToExistingParentModule){
+        options.moduleRoot = projectGraph.nodes[options.parentModuleName].data.root;
+    }
+    else {
+        const rootFolder = options.projectRoot.substring(0, lastIndexOfPathSlash);
+        options.moduleRoot = `${rootFolder}/${options.parentModuleName}`;
+    }
+    options.projectRoot = `${options.moduleRoot}/${options.projectRoot.substring(lastIndexOfPathSlash + 1)}`;
+}

--- a/packages/nx-spring-boot/src/generators/project/schema.d.ts
+++ b/packages/nx-spring-boot/src/generators/project/schema.d.ts
@@ -19,6 +19,11 @@ export interface ProjectGeneratorOptions {
   dependencies?: string;
   version?: string;
   skipFormat?: boolean;
+
+  transformIntoMultiModule?: boolean;
+  addToExistingParentModule?: boolean;
+  parentModuleName?: string;
+  keepProjectLevelWrapper?: boolean;
 }
 
 export interface NormalizedSchema extends ProjectGeneratorOptions {
@@ -27,4 +32,5 @@ export interface NormalizedSchema extends ProjectGeneratorOptions {
   projectDirectory: string;
   projectDependencies: string[];
   parsedTags: string[];
+  moduleRoot?: string;
 }

--- a/packages/nx-spring-boot/src/generators/project/schema.json
+++ b/packages/nx-spring-boot/src/generators/project/schema.json
@@ -176,13 +176,15 @@
       "description": "Artifact Id of the project.",
       "type": "string",
       "default": "demo",
-      "x-prompt": "What artifactId would you like to use?"
+      "x-prompt": "What artifactId would you like to use?",
+      "x-priority": "important"
     },
     "packageName": {
       "description": "Name of the main package of the project.",
       "type": "string",
       "default": "com.example.demo",
-      "x-prompt": "What package name would you like to use?"
+      "x-prompt": "What package name would you like to use?",
+      "x-priority": "important"
     },
     "description": {
       "description": "Description of the project.",
@@ -201,6 +203,23 @@
       "description": "Dependencies to use in the project (comma-separated). Follow this guide https://t.ly/Xyao for more instructions on how to proceed.",
       "type": "string",
       "x-priority": "important"
+    },
+    "transformIntoMultiModule": {
+      "description": "Transform the project into a multi-module project. Follow this guide https://t.ly/yvsp1 for more information.",
+      "type": "boolean"
+    },
+    "addToExistingParentModule": {
+      "description": "Add the project into an existing parent module project. Follow this guide https://t.ly/yvsp1 for more information.",
+      "type": "boolean"
+    },
+    "parentModuleName": {
+      "description": "Name of the parent module to create or to add child project into.",
+      "type": "string"
+    },
+    "keepProjectLevelWrapper": {
+      "description": "Keep the `Maven` or `Gradle` wrapper files from child project (when generating a multi-module project). Follow this guide https://t.ly/yvsp1 for more information.",
+      "type": "boolean",
+      "default": true
     },
     "springInitializerUrl": {
       "type": "string",

--- a/packages/nx-spring-boot/src/utils/boot-utils.ts
+++ b/packages/nx-spring-boot/src/utils/boot-utils.ts
@@ -14,6 +14,8 @@ import {
   getCommonHttpHeaders,
   NX_SPRING_BOOT_PKG,
   MavenDependency,
+  hasMultiModuleMavenProject,
+  hasMultiModuleGradleProject,
 } from '@nxrocks/common';
 import { MAVEN_BUILDER, GRADLE_BUILDER } from '../core/constants';
 import { ProjectConfiguration } from '@nx/devkit';
@@ -33,7 +35,7 @@ export const DEFAULT_SPRING_INITIALIZR_URL = 'https://start.spring.io';
 export function runBootPluginCommand(
   commandAlias: BuilderCommandAliasType,
   params: string[],
-  options: { cwd?: string; ignoreWrapper?: boolean } = { ignoreWrapper: false }
+  options: { cwd: string; ignoreWrapper?: boolean, runFromParentModule?: boolean } = { cwd: process.cwd(), ignoreWrapper: false, runFromParentModule: false }
 ): { success: boolean } {
   return runBuilderCommand(commandAlias, getBuilder, params, options);
 }
@@ -63,6 +65,10 @@ export function buildBootDownloadUrl(options: NormalizedSchema) {
 }
 
 export function isBootProject(project: ProjectConfiguration): boolean {
+
+  if(hasMultiModuleMavenProject(project.root) || hasMultiModuleGradleProject(project.root))
+    return true;
+
   if (isMavenProject(project)) {
     return checkProjectBuildFileContains(project, {
       fragments: ['<artifactId>spring-boot-starter-parent</artifactId>'],

--- a/tools/scripts/start-local-registry.ts
+++ b/tools/scripts/start-local-registry.ts
@@ -23,7 +23,7 @@ export default async () => {
   const nx = require.resolve('nx');
   execFileSync(
     nx,
-    ['run-many', '--targets', 'publish', '--ver', '0.0.0-e2e', '--tag', 'e2e'],
+    ['run-many', '--targets', 'publish', '--ver', '0.0.0-e2e', '--tag', 'latest'],
     { env: process.env, stdio: 'inherit' }
   );
 };


### PR DESCRIPTION
You can now generate `Spring Boot`, `Quarkus`, `Micronaut` and `Ktor` projects with **multi-modules** support using both `Maven` and `Gradle`.
The Project Graph was updated too, so that these new kind of projects can be visualised in the dependency graph.