### PR TITLE
[Feature] (nx-spring-boot) Add Support for Java 21

### DIFF
--- a/packages/nx-spring-boot/src/generators/project/schema.json
+++ b/packages/nx-spring-boot/src/generators/project/schema.json
@@ -110,12 +110,17 @@
         "1.8",
         "11",
         "17",
-        "19"
+        "19",
+        "21"
       ],
       "x-prompt": {
         "message": "Which version of Java would you like to use?",
         "type": "list",
         "items": [
+          {
+            "value": "21",
+            "label": "21"
+          },
           {
             "value": "19",
             "label": "19"


### PR DESCRIPTION
Closes #182

Is your feature request related to a problem? Please describe

https://start.spring.io/ now support Java 21 too
Describe the idea you'd like

Add Support for selecting Java version 21 when generating a Spring boot project.

Update the following files in packages/nx-spring-boot/src/generators/project:

    schema.json
    schema.d.ts

Describe alternatives you've considered

No response
Additional context

No response