### PR TITLE
Executors still not working in a multi-module project with more than one level of folders

### DIFF
--- a/packages/common-jvm/src/lib/builders/gradle-builder.class.ts
+++ b/packages/common-jvm/src/lib/builders/gradle-builder.class.ts
@@ -29,12 +29,11 @@ export class GradleBuilder implements BuilderCore {
     
     if (options.runFromParentModule) {
       let pathToModule:string[] = [];
-      const childModuleName = basename(cwd);
       do {
         const module = basename(cwd);
         cwd = resolve(cwd, '..');
         pathToModule = [module, ...pathToModule];
-      } while (!hasGradleModule(cwd, childModuleName));
+      } while (!hasGradleModule(cwd, pathToModule.join(':')));
 
       additionalArgs = `-p ${pathToModule.join('/')} `;
     }

--- a/packages/common-jvm/src/lib/builders/maven-builder.class.ts
+++ b/packages/common-jvm/src/lib/builders/maven-builder.class.ts
@@ -32,14 +32,15 @@ export class MavenBuilder implements BuilderCore {
     
     if(options.runFromParentModule){
       let pathToModule:string[] = [];
-      const childModuleName = basename(cwd);
+      let childModuleName = '';
       do {
         const module = basename(cwd);
         cwd = resolve(cwd, '..');
         pathToModule = [module, ...pathToModule];
+        childModuleName = pathToModule.join('/');
       } while (!hasMavenModule(cwd, childModuleName));
 
-      additionalArgs = `-f ${pathToModule.join('/')} `;
+      additionalArgs = `-f ${childModuleName} `;
     }
 
     return {cwd, command: `${additionalArgs}${this.commandAliases[alias]}`};


### PR DESCRIPTION
The PR #201 does not fully solve the detected issue #200.

It can't quite find the parent module. The reason: The `pom.xml` file needs to include the submodule path in the `modules` section, e.g.

```xml
<modules>
   <module>apps/demo</module>
</modules>
```

For gradle projects, the `settings.gradle` file includes the submodule path as well but using a colon as separator, e.g.

```
include 'apps:demo'
```

This PR tries to fix it.