### PR TITLE
Allow checkForModule to match child module names w/ arbitrary paths

### DIFF
--- a/packages/common-jvm/src/lib/utils/gradle-utils.ts
+++ b/packages/common-jvm/src/lib/utils/gradle-utils.ts
@@ -380,12 +380,12 @@ export function hasGradleModule(cwd:string, moduleName: string){
 
 function checkForModule(settings:string, moduleName:string){
   const opts = {
-    fragments: [new RegExp(`rootProject\\.name\\s*=\\s*'`), new RegExp(`include\\s+':?${moduleName}'`)],
+    fragments: [new RegExp(`rootProject\\.name\\s*=\\s*'`), new RegExp(`include\\s+':?(?:[^:]*:)*${moduleName}'`)],
     logicalOp: 'and' as 'and' | 'or'
   };
 
   const optsKts = {
-    fragments: [new RegExp(`rootProject\\.name\\s*=\\s*"`), new RegExp(`include\\(":?${moduleName}"\\)`)],
+    fragments: [new RegExp(`rootProject\\.name\\s*=\\s*"`), new RegExp(`include\\(":?(?:[^:]*:)*${moduleName}"\\)`)],
     logicalOp: 'and' as 'and' | 'or'
   };
 


### PR DESCRIPTION
We have a use-case where we have a root gradle project (e.g. in `root/`), and then gradle subprojects that live in various subdirectories (e.g. `root/apps/cool-app`, `root/libs/api/cool-lib`).

The problem is that our root level build.gradle then has entries like:
```
include 'apps:cool-app'
include 'libs:api:cool-lib'
```
And the current `checkForModule` assumes the subproject always lives in the same directory as root.

With the proposed regex change here, we can ensure the nx executors work correctly for `nx build cool-app`.