### PR TITLE
fix: nx inputs for build to ensure lint works properly

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -43,7 +43,7 @@
     "@nx/js:tsc": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "inputs": ["production", "^production"]
     },
     "@nx/eslint:lint": {
       "cache": true,
@@ -79,5 +79,14 @@
       }
     }
   ],
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*"],
+    "production": [
+      "default",
+      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/tsconfig.spec.json",
+      "!{projectRoot}/jest.config.[jt]s"
+    ]
+  },
   "defaultBase": "origin/develop"
 }


### PR DESCRIPTION
To ensure the [`dependancy-checks`](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) rules works properly, you need to have inputs that don't includes tests files.

> The rule uses the project graph to collect all the dependencies of your project, based on the input of your build target. It will filter out all the dependencies marked as devDependencies in your root package.json to ensure dependencies of your compilation pipelines (e.g. dependencies of webpack.config or vite.config) or test setups are not included in the expected list.
