### PR TITLE
fix(nx-quarkus): support javaVersion argument override for nx-quarkus package

### DIFF
--- a/e2e/nx-quarkus-e2e/tests/nx-quarkus.spec.ts
+++ b/e2e/nx-quarkus-e2e/tests/nx-quarkus.spec.ts
@@ -89,9 +89,10 @@ describe('nx-quarkus e2e', () => {
       const artifactId = 'api';
       //const version = '1.2.3'; https://github.com/nrwl/nx/issues/10786
       const extensions = 'resteasy';
+      const javaVersion = '21';
 
       await runNxCommandAsync(
-        `generate @nxrocks/nx-quarkus:new ${prjName} --projectType ${projectType} --buildSystem=${buildSystem} --groupId=${groupId} --artifactId=${artifactId} --extensions=${extensions} --no-interactive`
+        `generate @nxrocks/nx-quarkus:new ${prjName} --projectType ${projectType} --buildSystem=${buildSystem} --groupId=${groupId} --artifactId=${artifactId} --extensions=${extensions} --javaVersion ${javaVersion} --no-interactive`
       );
 
       const resultBuild = await runNxCommandAsync(`build ${prjName}`);
@@ -112,6 +113,9 @@ describe('nx-quarkus e2e', () => {
       expect(pomXml).toContain(`<groupId>${groupId}</groupId>`);
       expect(pomXml).toContain(`<artifactId>${artifactId}</artifactId>`);
       //expect(pomXml).toContain(`<version>${version}</version>`);
+      expect(pomXml).toContain(
+        `<maven.compiler.releasez>21</maven.compiler.release>`
+      );
 
       // make sure the build wrapper file is executable (*nix only)
       if (!isWin) {

--- a/packages/nx-quarkus/README.md
+++ b/packages/nx-quarkus/README.md
@@ -130,6 +130,7 @@ Here the list of available generation options :
 | `skipeCodeSamples`          | `string`                   | Whether or not to include code samples from extensions (when available)                                                                                                                                 |
 | `tags`                      | `string`                   | Tags to use for linting (comma-separated)                                                                                                                                                               |
 | `directory`                 | `string`                   | Directory where the project is placed                                                                                                                                                                   |
+| `javaVersion`               | `string \| number`         | The java version of the project (currently supports versions 17 and 21)                                                                                                                                 |
 
 > **Note:** If you are working behind a corporate proxy, you can use the `proxyUrl` option to specify the URL of that corporate proxy server.
 > Otherwise, you'll get a [ETIMEDOUT error](https://github.com/tinesoft/nxrocks/issues/125) when trying to access official Quarkus Initializer to generate the project.

--- a/packages/nx-quarkus/src/generators/project/schema.json
+++ b/packages/nx-quarkus/src/generators/project/schema.json
@@ -70,7 +70,14 @@
     },
     "javaVersion": {
       "description": "Java version.",
-      "type": "string",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ],
       "default": "17",
       "enum": ["17", "21"],
       "x-prompt": {


### PR DESCRIPTION
This tries to address a project generator validation error on the `javaVersion` argument. Currently when passing `javaVersion` as an argument you get the error message "Property 'javaVersion' does not match the schema. '17' should be a 'string'.".

This worked when I was on version `8.0.1` of the nx-quarkus plugin, but after upgrading to the latest I started seeing this error.

I couldn't get the dev container setup to work to run the e2e tests and validate the behavior fully.

A couple issues/fixes I saw that seemed relevant that I used to model this change after: 
- An issue created in the nx repo that describes string arguments being interpreted as boolean values: https://github.com/nrwl/nx/issues/10786
- A fix for the spring-boot project where a similar issue was reported: https://github.com/nrwl/nx/issues/10786https://github.com/tinesoft/nxrocks/commit/364b22885e74706fd3f6d10323325323439aa2f1


I'd love to be able to get the dev container setup working to be able to contribute to this project more regularly. I'm looking to use it in some critical projects, I may just need a little help/guidance troubleshooting my devcontainer issue. I'm able to run the regular tests, but the verdaccio connection times out when running the e2e tests.