### PR TITLE
docs: Fix broken link in nx-flutter README.md

### DIFF
--- a/packages/nx-flutter/README.md
+++ b/packages/nx-flutter/README.md
@@ -49,7 +49,7 @@ Here is a list of some of the coolest features of the plugin:
 >
 > and you are good to go‧o‧o‧o! 🚀
 >
-> More information here: [create-nx-flutter](../packages/create-nx-flutter/README.md)
+> More information here: [create-nx-flutter](../create-nx-flutter/README.md)
 
 </details>
 


### PR DESCRIPTION
The path navigated to a non existing page because it led to 'packages/packages/...etc'. See screenshot.

<img width="861" alt="image" src="https://github.com/user-attachments/assets/04ef2e66-6c79-4386-913f-8faf80d22896">

-

PS. I just noticed that your commit style is in all lowercase - apologies for breaking the trend with a capital letter :p