### PR TITLE
fix(nx-flutter): restrict ios-language flag to plugin templates only

### DIFF
--- a/packages/nx-flutter/src/generators/project/generator.spec.ts
+++ b/packages/nx-flutter/src/generators/project/generator.spec.ts
@@ -116,7 +116,7 @@ describe('application generator', () => {
     async ({ template }) => {
       await projectGenerator(tree, { ...options, template: template });
 
-      if (['app', 'plugin'].includes(template)) {
+      if (template === 'plugin') {
         expect(logger.info).toHaveBeenNthCalledWith(
           1,
           '⚙️ Generating project configuration...'
@@ -128,6 +128,19 @@ describe('application generator', () => {
         expect(logger.info).toHaveBeenNthCalledWith(
           3,
           `Executing command: flutter create --project-name=${options.name} --android-language=kotlin --ios-language=swift --template=${template} --platforms="android,ios,web,linux,windows,macos"  ${options.name}`
+        );
+      } else if (template === 'app') {
+        expect(logger.info).toHaveBeenNthCalledWith(
+          1,
+          '⚙️ Generating project configuration...'
+        );
+        expect(logger.info).toHaveBeenNthCalledWith(
+          2,
+          `Generating Flutter project with following options : --project-name=${options.name} --android-language=kotlin --template=${template} --platforms="android,ios,web,linux,windows,macos" ...`
+        );
+        expect(logger.info).toHaveBeenNthCalledWith(
+          3,
+          `Executing command: flutter create --project-name=${options.name} --android-language=kotlin --template=${template} --platforms="android,ios,web,linux,windows,macos"  ${options.name}`
         );
       } else {
         expect(logger.info).toHaveBeenNthCalledWith(

--- a/packages/nx-flutter/src/generators/project/lib/prompt-additional-options.ts
+++ b/packages/nx-flutter/src/generators/project/lib/prompt-additional-options.ts
@@ -13,84 +13,93 @@ type PromptResultType = {
   iosLanguage?: IosLanguageType;
 };
 
-export async function promptAdditionalOptions(tree: Tree, options: NormalizedSchema) {
-    if (process.env.NX_INTERACTIVE === 'true' && ['app', 'plugin'].includes(options.template)) {
-
-        await prompt([
+export async function promptAdditionalOptions(
+  tree: Tree,
+  options: NormalizedSchema
+) {
+  if (
+    process.env.NX_INTERACTIVE === 'true' &&
+    ['app', 'plugin'].includes(options.template)
+  ) {
+    await prompt([
+      {
+        name: 'platforms',
+        type: 'multiselect',
+        choices: [
           {
-            name: 'platforms',
-            type: 'multiselect',
-            choices: [
-                {
-                    name: "android",
-                    value: "Android platform",
-                },
-                {
-                    name: "ios",
-                    value: "iOS platform",
-                },
-                {
-                    name: "linux",
-                    value: "Linux platform",
-                },
-                {
-                    name: "windows",
-                    value: "Windows platform",
-                },
-                {
-                    name: "macos",
-                    value: "MacOS platform",
-                },
-                {
-                    name: "web",
-                    value: "Web platform",
-                }
-            ],
-            validate: (platforms) => {
-                return platforms?.length ? true : 'You must select at least one platform'
+            name: 'android',
+            value: 'Android platform',
+          },
+          {
+            name: 'ios',
+            value: 'iOS platform',
+          },
+          {
+            name: 'linux',
+            value: 'Linux platform',
+          },
+          {
+            name: 'windows',
+            value: 'Windows platform',
+          },
+          {
+            name: 'macos',
+            value: 'MacOS platform',
+          },
+          {
+            name: 'web',
+            value: 'Web platform',
+          },
+        ],
+        validate: (platforms) => {
+          return platforms?.length
+            ? true
+            : 'You must select at least one platform';
+        },
+        message: 'Which platforms would you like to use?',
+      },
+    ]).then(async (result: Partial<PromptResultType>) => {
+      const languages: Partial<PromptResultType> = await prompt([
+        {
+          skip: () => result.platforms?.indexOf('android') === -1,
+          name: 'androidLanguage',
+          type: 'select',
+          initial: 1,
+          choices: [
+            {
+              name: 'java',
+              value: 'Java',
             },
-            message: 'Which platforms would you like to use?'
-        }]).then(async (result: Partial<PromptResultType>) => {
-
-            const languages: Partial<PromptResultType> = await prompt([
-                {
-                    skip: () => result.platforms?.indexOf('android') === -1,
-                    name: 'androidLanguage',
-                    type: 'select',
-                    initial: 1,
-                    choices: [
-                        {
-                            name: "java",
-                            value: "Java"
-                        },
-                        {
-                            name: "kotlin",
-                            value: "Kotlin"
-                        }
-                    ],
-                    message: "Which Android language would you like to use?",
-                },
-                {
-                    skip: () => result.platforms?.indexOf('ios') === -1,
-                    name: 'iosLanguage',
-                    type: 'select',
-                    initial: 1,
-                    choices: [
-                        {
-                            name: "objc",
-                            value: "Objective-C"
-                        },
-                        {
-                            name: "swift",
-                            value: "Swift"
-                        }
-                    ],
-                    message: "Which iOS language would you like to use?",
-                }
-            ]);
-            options.platforms = result?.platforms;
-            options.androidLanguage = languages?.androidLanguage;
-            options.iosLanguage = languages?.iosLanguage;
-        });
-    }
+            {
+              name: 'kotlin',
+              value: 'Kotlin',
+            },
+          ],
+          message: 'Which Android language would you like to use?',
+        },
+        {
+          skip: () =>
+            result.platforms?.indexOf('ios') === -1 ||
+            options.template !== 'plugin',
+          name: 'iosLanguage',
+          type: 'select',
+          initial: 1,
+          choices: [
+            {
+              name: 'objc',
+              value: 'Objective-C',
+            },
+            {
+              name: 'swift',
+              value: 'Swift',
+            },
+          ],
+          message: 'Which iOS language would you like to use?',
+        },
+      ]);
+      options.platforms = result?.platforms;
+      options.androidLanguage = languages?.androidLanguage;
+      options.iosLanguage = languages?.iosLanguage;
+    });
+  }
 }

--- a/packages/nx-flutter/src/utils/flutter-utils.ts
+++ b/packages/nx-flutter/src/utils/flutter-utils.ts
@@ -36,7 +36,10 @@ export function buildFlutterCreateOptions(options: NormalizedSchema) {
     { key: 'org', value: options.org },
     { key: 'description', value: quote(options.description) },
     { key: 'android-language', value: options.androidLanguage },
-    { key: 'ios-language', value: options.iosLanguage },
+    {
+      key: 'ios-language',
+      value: options.template === 'plugin' ? options.iosLanguage : null,
+    },
     { key: 'template', value: options.template },
     { key: 'sample', value: options.sample },
     {


### PR DESCRIPTION
## Issue

Starting with Flutter 3.35+, the `--ios-language` flag is only supported for plugin templates. Passing this flag to other template types (app, module, package) causes the generator to fail with an error.

## Failing Command

```bash
flutter create --project-name=ui_atom --org=com.example --android-language=kotlin --ios-language=swift --template=module libs/ui/ui-atom
```

Error: `The "ios-language" option is only supported for "--template=plugin".`

## Fix

This PR restricts the `--ios-language` flag to only be included when generating plugin templates. For all other templates (app, module, package), the flag is now excluded from the Flutter create command.

The fix also updates the interactive prompts to only ask for iOS language selection when the user is creating a plugin template.

## Test Plan

Tested with all template types to verify that only plugin templates include the `--ios-language` flag in the generated Flutter create command.